### PR TITLE
Nested transaction

### DIFF
--- a/packages/accel-record-core/src/testUtils.ts
+++ b/packages/accel-record-core/src/testUtils.ts
@@ -2,10 +2,10 @@ import { Model } from "./index.js";
 
 export class DatabaseCleaner {
   static start() {
-    Model.startTransaction();
+    Model.startNestableTransaction();
   }
 
   static clean() {
-    Model.rollbackTransaction();
+    Model.rollbackNestableTransaction();
   }
 }

--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -76,8 +76,8 @@ export class Transaction {
     try {
       callback();
     } catch (e) {
+      this.rollbackNestableTransaction();
       if (e instanceof Rollback) {
-        this.rollbackNestableTransaction();
         return;
       } else {
         throw e;

--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -34,6 +34,11 @@ export class Transaction {
     execSQL({ sql: "ROLLBACK;", bindings: [] });
   }
 
+  /**
+   * Starts a nestable transaction.
+   * If the transaction count is 0, it begins a new transaction using the `BEGIN;` SQL statement.
+   * If the transaction count is greater than 0, it creates a savepoint using the `SAVEPOINT` SQL statement.
+   */
   static startNestableTransaction() {
     if (this.transactionCount == 0) {
       execSQL({ sql: "BEGIN;", bindings: [] });
@@ -46,6 +51,10 @@ export class Transaction {
     this.transactionCount++;
   }
 
+  /**
+   * Rolls back the current nestable transaction.
+   * Decrements the transaction count and rolls back to the appropriate savepoint or performs a full rollback if no savepoints remain.
+   */
   static rollbackNestableTransaction() {
     this.transactionCount--;
     if (this.transactionCount == 0) {
@@ -58,6 +67,10 @@ export class Transaction {
     }
   }
 
+  /**
+   * Decrements the transaction count and attempts to commit the nestable transaction.
+   * If the transaction count reaches 0, the transaction is committed.
+   */
   static tryCommitNestableTransaction() {
     this.transactionCount--;
     if (this.transactionCount == 0) {
@@ -66,9 +79,10 @@ export class Transaction {
   }
 
   /**
-   * Executes a transaction by invoking the provided callback function.
-   * If an exception of type `Rollback` is thrown within the callback, the transaction will be rolled back.
-   * Otherwise, the transaction will be committed.
+   * Executes a transaction by starting a nestable transaction, executing the provided callback,
+   * and then attempting to commit the transaction.
+   * If an error occurs during the callback execution, the transaction is rolled back.
+   *
    * @param callback - The callback function to be executed within the transaction.
    */
   static transaction(callback: () => void) {

--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -12,7 +12,7 @@ export class Rollback extends Error {
  * This class is intended to be inherited by the Model class.
  */
 export class Transaction {
-  static transactionStack: number[] = [];
+  protected static transactionCount: number = 0;
   /**
    * Starts a new transaction.
    */
@@ -34,6 +34,37 @@ export class Transaction {
     execSQL({ sql: "ROLLBACK;", bindings: [] });
   }
 
+  static startNestableTransaction() {
+    if (this.transactionCount == 0) {
+      execSQL({ sql: "BEGIN;", bindings: [] });
+    } else {
+      execSQL({
+        sql: `SAVEPOINT accel_record_${this.transactionCount};`,
+        bindings: [],
+      });
+    }
+    this.transactionCount++;
+  }
+
+  static rollbackNestableTransaction() {
+    this.transactionCount--;
+    if (this.transactionCount == 0) {
+      execSQL({ sql: "ROLLBACK;", bindings: [] });
+    } else {
+      execSQL({
+        sql: `ROLLBACK TO SAVEPOINT accel_record_${this.transactionCount};`,
+        bindings: [],
+      });
+    }
+  }
+
+  static tryCommitNestableTransaction() {
+    this.transactionCount--;
+    if (this.transactionCount == 0) {
+      execSQL({ sql: "COMMIT;", bindings: [] });
+    }
+  }
+
   /**
    * Executes a transaction by invoking the provided callback function.
    * If an exception of type `Rollback` is thrown within the callback, the transaction will be rolled back.
@@ -41,34 +72,17 @@ export class Transaction {
    * @param callback - The callback function to be executed within the transaction.
    */
   static transaction(callback: () => void) {
-    const latest = this.transactionStack[this.transactionStack.length - 1] ?? 0;
-    this.transactionStack.push(latest + 1);
-    if (latest == 0) {
-      execSQL({ sql: "BEGIN;", bindings: [] });
-    } else {
-      execSQL({ sql: `SAVEPOINT accel_record_${latest};`, bindings: [] });
-    }
+    this.startNestableTransaction();
     try {
       callback();
     } catch (e) {
       if (e instanceof Rollback) {
-        if (latest == 0) {
-          execSQL({ sql: "ROLLBACK;", bindings: [] });
-        } else {
-          execSQL({
-            sql: `ROLLBACK TO SAVEPOINT accel_record_${latest};`,
-            bindings: [],
-          });
-        }
-        this.transactionStack.pop();
+        this.rollbackNestableTransaction();
         return;
       } else {
         throw e;
       }
     }
-    if (latest == 0) {
-      this.commitTransaction();
-    }
-    this.transactionStack.pop();
+    this.tryCommitNestableTransaction();
   }
 }

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -3,12 +3,6 @@ import { $user } from "../factories/user";
 import { User } from "./index.js";
 
 describe("Transaction", () => {
-  beforeEach(() => {
-    Model.rollbackTransaction(); // for transaction for each test
-  });
-  afterEach(() => {
-    Model.startTransaction(); // for transaction for each test
-  });
   test(".transaction()", () => {
     Model.transaction(() => {
       $user.create({ name: "hoge" });
@@ -20,15 +14,7 @@ describe("Transaction", () => {
 });
 
 describe("nested Transaction", () => {
-  beforeEach(() => {
-    Model.rollbackTransaction(); // for transaction for each test
-  });
-  afterEach(() => {
-    Model.startTransaction(); // for transaction for each test
-  });
-
-  test(".transaction()", () => {
-    User.all().deleteAll();
+  test("commited, rollbacked ", () => {
     Model.transaction(() => {
       $user.create({ name: "hoge" });
       expect(User.count()).toBe(1);
@@ -41,11 +27,9 @@ describe("nested Transaction", () => {
       expect(User.count()).toBe(1);
     }); // commited
     expect(User.count()).toBe(1);
-    User.all().deleteAll();
   });
 
-  test(".transaction()", () => {
-    User.all().deleteAll();
+  test("rollbacked, rollbacked", () => {
     Model.transaction(() => {
       $user.create({ name: "hoge" });
       expect(User.count()).toBe(1);
@@ -55,9 +39,9 @@ describe("nested Transaction", () => {
         expect(User.count()).toBe(2);
         throw new Rollback();
       });
+      expect(User.count()).toBe(1);
       throw new Rollback();
     }); // rollbacked
     expect(User.count()).toBe(0);
-    User.all().deleteAll();
   });
 });

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -18,3 +18,46 @@ describe("Transaction", () => {
     expect(User.all().toArray()).toHaveLength(0);
   });
 });
+
+describe("nested Transaction", () => {
+  beforeEach(() => {
+    Model.rollbackTransaction(); // for transaction for each test
+  });
+  afterEach(() => {
+    Model.startTransaction(); // for transaction for each test
+  });
+
+  test(".transaction()", () => {
+    User.all().deleteAll();
+    Model.transaction(() => {
+      $user.create({ name: "hoge" });
+      expect(User.count()).toBe(1);
+
+      Model.transaction(() => {
+        $user.create({ name: "fuga" });
+        expect(User.count()).toBe(2);
+        throw new Rollback();
+      });
+      expect(User.count()).toBe(1);
+    }); // commited
+    expect(User.count()).toBe(1);
+    User.all().deleteAll();
+  });
+
+  test(".transaction()", () => {
+    User.all().deleteAll();
+    Model.transaction(() => {
+      $user.create({ name: "hoge" });
+      expect(User.count()).toBe(1);
+
+      Model.transaction(() => {
+        $user.create({ name: "fuga" });
+        expect(User.count()).toBe(2);
+        throw new Rollback();
+      });
+      throw new Rollback();
+    }); // rollbacked
+    expect(User.count()).toBe(0);
+    User.all().deleteAll();
+  });
+});

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -44,4 +44,23 @@ describe("nested Transaction", () => {
     }); // rollbacked
     expect(User.count()).toBe(0);
   });
+
+  test("with Error", () => {
+    try {
+      Model.transaction(() => {
+        $user.create({ name: "hoge" });
+        expect(User.count()).toBe(1);
+
+        Model.transaction(() => {
+          $user.create({ name: "fuga" });
+          expect(User.count()).toBe(2);
+          throw new Error();
+        });
+        // It will not reach here
+        assert(false);
+      }); // rollbacked
+    } catch (e) {
+      expect(User.count()).toBe(0);
+    }
+  });
 });


### PR DESCRIPTION
You can use nestable transaction now.

Example (by test):

```ts
Model.transaction(() => {
  User.create({ name: "foo" });
  expect(User.count()).toBe(1);

  Model.transaction(() => {
    User.create({ name: "bar" });
    expect(User.count()).toBe(2);
    throw new Rollback();
  });
  
  expect(User.count()).toBe(1);
}); // commited
expect(User.count()).toBe(1);
```