### PR TITLE
Removal of `ModelMeta["OrderInput"]`

### DIFF
--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -32,8 +32,6 @@ export type Meta<T> = ReturnType<typeof meta<T>>;
 
 export declare function meta<T>(model: T): ModelMeta;
 
-export type SortOrder = "asc" | "desc";
-
 export type Filter<T> = {
   in?: T[];
   "<"?: T;

--- a/packages/accel-record-core/src/meta.ts
+++ b/packages/accel-record-core/src/meta.ts
@@ -1,4 +1,4 @@
-import { Meta, Model, SortOrder } from "./index.js";
+import { Meta, Model } from "./index.js";
 
 export type { Meta };
 export type Persisted<T> = Meta<T>["Persisted"];
@@ -12,5 +12,4 @@ export type ModelMeta = {
   Column: Record<string, any>;
   WhereInput: Record<string, any>;
   CreateInput: Record<string, any>;
-  OrderInput: Record<string, SortOrder>;
 };

--- a/packages/accel-record-core/src/model/dirty.ts
+++ b/packages/accel-record-core/src/model/dirty.ts
@@ -27,7 +27,7 @@ export class Dirty {
    */
   isAttributeChanged<T extends Model>(
     this: T,
-    attribute: keyof Meta<T>["OrderInput"]
+    attribute: keyof Meta<T>["Column"]
   ): boolean {
     return (
       this[attribute as keyof T] !== this.originalValues[attribute as string]
@@ -42,7 +42,7 @@ export class Dirty {
    */
   isChanged<T extends Model>(
     this: T,
-    attribute?: keyof Meta<T>["OrderInput"]
+    attribute?: keyof Meta<T>["Column"]
   ): boolean {
     if (attribute) {
       return this.isAttributeChanged(attribute);

--- a/packages/accel-record-core/src/model/import.ts
+++ b/packages/accel-record-core/src/model/import.ts
@@ -19,14 +19,14 @@ type ImportOptions<T extends typeof Model> = {
    * - If not provided or set to `true`, existing records will be updated.
    * - If set to an array of keys, only the specified keys will be updated.
    */
-  onDuplicateKeyUpdate?: true | (keyof Meta<T>["OrderInput"])[];
+  onDuplicateKeyUpdate?: true | (keyof Meta<T>["Column"])[];
 
   /**
    * Specifies the conflict target for resolving conflicts when a duplicate key is encountered.
    * - If not provided, the entire record will be considered as the conflict target.
    * - If set to an array of keys, only the specified keys will be considered as the conflict target.
    */
-  conflictTarget?: (keyof Meta<T>["OrderInput"])[];
+  conflictTarget?: (keyof Meta<T>["Column"])[];
 };
 
 type ImportResult<T extends typeof Model> = {

--- a/packages/accel-record-core/src/model/serialization.ts
+++ b/packages/accel-record-core/src/model/serialization.ts
@@ -51,7 +51,7 @@ type ToHashMethods<
 
 export type ToHashResult<T, O extends ToHashOptions<T>> = {
   [K in undefined extends O["only"]
-    ? Exclude<keyof Meta<T>["OrderInput"], ToUnion<O["except"]>>
+    ? Exclude<keyof Meta<T>["Column"], ToUnion<O["except"]>>
     : ToUnion<O["only"]>]: T[Extract<K, keyof T>];
 } & ToHashInclude<O, T> &
   ToHashMethods<O, T>;
@@ -67,8 +67,8 @@ type NoArgMethods<T> = {
 }[keyof T];
 
 export type ToHashOptions<T> = {
-  only?: (keyof Meta<T>["OrderInput"])[];
-  except?: (keyof Meta<T>["OrderInput"])[];
+  only?: (keyof Meta<T>["Column"])[];
+  except?: (keyof Meta<T>["Column"])[];
   methods?: NoArgMethods<T>[];
   include?: Meta<T>["AssociationKey"] | ToHashIncludeOption<T>;
 };

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -97,10 +97,7 @@ export class Query {
    * @param columns - The columns to select.
    * @returns A `Relation` object representing the query result with the selected columns.
    */
-  static select<
-    T extends typeof Model,
-    F extends (keyof Meta<T>["OrderInput"])[],
-  >(
+  static select<T extends typeof Model, F extends (keyof Meta<T>["Column"])[]>(
     this: T,
     ...attributes: F
     // @ts-ignore
@@ -209,7 +206,7 @@ export class Query {
    */
   static order<T extends typeof Model>(
     this: T,
-    attribute: keyof Meta<T>["OrderInput"],
+    attribute: keyof Meta<T>["Column"],
     direction?: "asc" | "desc"
   ): Relation<InstanceType<T>, Meta<T>> {
     return this.all().order(attribute, direction);
@@ -338,7 +335,7 @@ export class Query {
    */
   static maximum<T extends typeof Model>(
     this: T,
-    attribute: keyof Meta<T>["OrderInput"]
+    attribute: keyof Meta<T>["Column"]
   ) {
     return this.all().maximum(attribute);
   }
@@ -350,7 +347,7 @@ export class Query {
    */
   static minimum<T extends typeof Model>(
     this: T,
-    attribute: keyof Meta<T>["OrderInput"]
+    attribute: keyof Meta<T>["Column"]
   ) {
     return this.all().minimum(attribute);
   }
@@ -362,7 +359,7 @@ export class Query {
    */
   static average<T extends typeof Model>(
     this: T,
-    attribute: keyof Meta<T>["OrderInput"]
+    attribute: keyof Meta<T>["Column"]
   ) {
     return this.all().average(attribute);
   }

--- a/packages/accel-record-core/src/relation/calculations.ts
+++ b/packages/accel-record-core/src/relation/calculations.ts
@@ -27,7 +27,7 @@ export class Calculations {
    */
   minimum<T, M extends ModelMeta>(
     this: Relation<T, M>,
-    attribute: keyof M["OrderInput"]
+    attribute: keyof M["Column"]
   ) {
     const res = exec(
       this.query().min(this.model.attributeToColumn(attribute as string))
@@ -43,7 +43,7 @@ export class Calculations {
    */
   maximum<T, M extends ModelMeta>(
     this: Relation<T, M>,
-    attribute: keyof M["OrderInput"]
+    attribute: keyof M["Column"]
   ) {
     const res = exec(
       this.query().max(this.model.attributeToColumn(attribute as string))
@@ -59,7 +59,7 @@ export class Calculations {
    */
   average<T, M extends ModelMeta>(
     this: Relation<T, M>,
-    attribute: keyof M["OrderInput"]
+    attribute: keyof M["Column"]
   ) {
     const res = exec(
       this.query().avg(this.model.attributeToColumn(attribute as string))

--- a/packages/accel-record-core/src/relation/query.ts
+++ b/packages/accel-record-core/src/relation/query.ts
@@ -98,7 +98,7 @@ export class Query {
    */
   order<T, M extends ModelMeta>(
     this: Relation<T, M>,
-    attribute: keyof M["OrderInput"],
+    attribute: keyof M["Column"],
     direction: "asc" | "desc" = "asc"
   ): Relation<T, M> {
     const newOptions = JSON.parse(JSON.stringify(this.options));
@@ -164,7 +164,7 @@ export class Query {
   select<
     T,
     M extends ModelMeta,
-    F extends (keyof M["OrderInput"])[],
+    F extends (keyof M["Column"])[],
     // @ts-ignore
     R extends { [K in F[number]]: M["Persisted"][K] },
   >(

--- a/packages/accel-record-core/src/validation/validator/uniqueness.ts
+++ b/packages/accel-record-core/src/validation/validator/uniqueness.ts
@@ -3,7 +3,7 @@ import { Validator } from "./index.js";
 
 export type UniqunessOptions<T> =
   | boolean
-  | { scope: (keyof Meta<T>["OrderInput"] & string)[] };
+  | { scope: (keyof Meta<T>["Column"] & string)[] };
 
 export class UniquenessValidator<T extends Model> extends Validator<T> {
   constructor(

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -111,7 +111,6 @@ export const generateTypes = (options: GeneratorOptions) => {
   registerModel,
   type Collection,
   type Filter,
-  type SortOrder,
   type StringFilter,
 } from "accel-record";
 
@@ -161,12 +160,6 @@ declare module "accel-record" {
         return ` & ({ ${f.name}: ${f.type} } | { ${foreignKeys} })`;
       })
       .join("");
-    const orderInputs =
-      model.fields
-        .filter(reject)
-        .filter((field) => field.relationName == undefined)
-        .map((field) => `\n    ${field.name}?: SortOrder;`)
-        .join("") + "\n  ";
     data += `
 declare module "./${model.fileName}" {
   interface ${model.baseModel} {
@@ -187,7 +180,6 @@ type ${model.meta} = {
 ${columns}
   }${associationColumns};
   WhereInput: {${whereInputs(model)}};
-  OrderInput: {${orderInputs}};
 };
 registerModel(${model.persistedModel});
 `;

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -16,7 +16,6 @@ import {
   registerModel,
   type Collection,
   type Filter,
-  type SortOrder,
   type StringFilter,
 } from "accel-record";
 
@@ -113,14 +112,6 @@ type UserMeta = {
     createdAt?: Date | Date[] | Filter<Date> | null;
     updatedAt?: Date | Date[] | Filter<Date> | null;
   };
-  OrderInput: {
-    id?: SortOrder;
-    email?: SortOrder;
-    name?: SortOrder;
-    age?: SortOrder;
-    createdAt?: SortOrder;
-    updatedAt?: SortOrder;
-  };
 };
 registerModel(User);
 
@@ -158,10 +149,6 @@ type TeamMeta = {
   WhereInput: {
     id?: number | number[] | Filter<number> | null;
     name?: string | string[] | StringFilter | null;
-  };
-  OrderInput: {
-    id?: SortOrder;
-    name?: SortOrder;
   };
 };
 registerModel(Team);
@@ -209,12 +196,6 @@ type UserTeamMeta = {
     teamId?: number | number[] | Filter<number> | null;
     assignedAt?: Date | Date[] | Filter<Date> | null;
     assignedBy?: string | string[] | StringFilter | null;
-  };
-  OrderInput: {
-    userId?: SortOrder;
-    teamId?: SortOrder;
-    assignedAt?: SortOrder;
-    assignedBy?: SortOrder;
   };
 };
 registerModel(UserTeam);
@@ -269,13 +250,6 @@ type PostMeta = {
     author?: User | User[];
     authorId?: number | number[] | Filter<number> | null;
   };
-  OrderInput: {
-    id?: SortOrder;
-    title?: SortOrder;
-    content?: SortOrder;
-    published?: SortOrder;
-    authorId?: SortOrder;
-  };
 };
 registerModel(Post);
 
@@ -313,10 +287,6 @@ type PostTagMeta = {
   WhereInput: {
     id?: number | number[] | Filter<number> | null;
     name?: string | string[] | StringFilter | null;
-  };
-  OrderInput: {
-    id?: SortOrder;
-    name?: SortOrder;
   };
 };
 registerModel(PostTag);
@@ -363,13 +333,6 @@ type SettingMeta = {
     userId?: number | number[] | Filter<number> | null;
     threshold?: number | number[] | Filter<number> | null;
     createdAt?: Date | Date[] | Filter<Date> | null;
-  };
-  OrderInput: {
-    settingId?: SortOrder;
-    userId?: SortOrder;
-    threshold?: SortOrder;
-    createdAt?: SortOrder;
-    data?: SortOrder;
   };
 };
 registerModel(Setting);
@@ -430,16 +393,6 @@ type ProfileMeta = {
     uuid?: string | string[] | StringFilter | null;
     cuid?: string | string[] | StringFilter | null;
   };
-  OrderInput: {
-    id?: SortOrder;
-    userId?: SortOrder;
-    bio?: SortOrder;
-    point?: SortOrder;
-    enabled?: SortOrder;
-    role?: SortOrder;
-    uuid?: SortOrder;
-    cuid?: SortOrder;
-  };
 };
 registerModel(Profile);
 
@@ -477,10 +430,6 @@ type CompanyMeta = {
   WhereInput: {
     id?: number | number[] | Filter<number> | null;
     name?: string | string[] | StringFilter | null;
-  };
-  OrderInput: {
-    id?: SortOrder;
-    name?: SortOrder;
   };
 };
 registerModel(Company);
@@ -521,11 +470,6 @@ type EmployeeMeta = {
     name?: string | string[] | StringFilter | null;
     companyId?: number | number[] | Filter<number> | null;
     company?: Company | Company[];
-  };
-  OrderInput: {
-    id?: SortOrder;
-    name?: SortOrder;
-    companyId?: SortOrder;
   };
 };
 registerModel(Employee);
@@ -579,14 +523,6 @@ type ValidateSampleMeta = {
     key?: string | string[] | StringFilter | null;
     count?: number | number[] | Filter<number> | null;
     size?: string | string[] | StringFilter | null;
-  };
-  OrderInput: {
-    id?: SortOrder;
-    accepted?: SortOrder;
-    pattern?: SortOrder;
-    key?: SortOrder;
-    count?: SortOrder;
-    size?: SortOrder;
   };
 };
 registerModel(ValidateSample);


### PR DESCRIPTION
`ModelMeta["OrderInput"]` has been removed as it can be replaced with `ModelMeta["Column"]`.