### PR TITLE
Transaction improvement (returning the result of the callback, supporting asynchronous callbacks)

### DIFF
--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -86,9 +86,32 @@ export class Transaction {
    * @param callback - The callback function to be executed within the transaction.
    * @returns The return value of the callback function. If the transaction is rolled back, `undefined` is returned.
    */
+  static transaction<F extends () => Promise<any>>(
+    callback: F
+  ): Promise<Awaited<ReturnType<F>> | undefined>;
   static transaction<F extends () => any>(
     callback: F
-  ): ReturnType<F> | undefined {
+  ): ReturnType<F> | undefined;
+  static transaction<F extends () => any>(callback: F): any {
+    if (callback.constructor.name === "AsyncFunction") {
+      return new Promise(async (resolve, reject) => {
+        let result = undefined;
+        this.startNestableTransaction();
+        try {
+          result = await callback();
+        } catch (e) {
+          this.rollbackNestableTransaction();
+          if (e instanceof Rollback) {
+            resolve(undefined);
+          } else {
+            reject(e);
+          }
+          return;
+        }
+        this.tryCommitNestableTransaction();
+        resolve(result);
+      });
+    }
     let result = undefined;
     this.startNestableTransaction();
     try {

--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -84,19 +84,24 @@ export class Transaction {
    * If an error occurs during the callback execution, the transaction is rolled back.
    *
    * @param callback - The callback function to be executed within the transaction.
+   * @returns The return value of the callback function. If the transaction is rolled back, `undefined` is returned.
    */
-  static transaction(callback: () => void) {
+  static transaction<F extends () => any>(
+    callback: F
+  ): ReturnType<F> | undefined {
+    let result = undefined;
     this.startNestableTransaction();
     try {
-      callback();
+      result = callback();
     } catch (e) {
       this.rollbackNestableTransaction();
       if (e instanceof Rollback) {
-        return;
+        return undefined;
       } else {
         throw e;
       }
     }
     this.tryCommitNestableTransaction();
+    return result;
   }
 }

--- a/packages/accel-record-core/src/transaction.ts
+++ b/packages/accel-record-core/src/transaction.ts
@@ -86,6 +86,7 @@ export class Transaction {
    * @param callback - The callback function to be executed within the transaction.
    * @returns The return value of the callback function. If the transaction is rolled back, `undefined` is returned.
    */
+  static transaction<F extends () => never>(callback: F): undefined;
   static transaction<F extends () => Promise<any>>(
     callback: F
   ): Promise<Awaited<ReturnType<F>> | undefined>;

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -979,6 +979,7 @@ User.import(users, {
 `Model.transaction()` メソッドでトランザクションを利用できます。`Rollback` を例外として投げることでトランザクションをロールバックすることができ、トランザクションはネストすることができます。
 
 ```ts
+import { Rollback } from "accel-record";
 import { User } from "./models/index.js";
 
 User.transaction(() => {

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -978,6 +978,7 @@ User.import(users, {
 You can use the `Model.transaction()` method to utilize transactions. By throwing a `Rollback` exception, you can rollback the transaction, and transactions can be nested.
 
 ```ts
+import { Rollback } from "accel-record";
 import { User } from "./models/index.js";
 
 User.transaction(() => {

--- a/tests/models/init.test.ts
+++ b/tests/models/init.test.ts
@@ -1,4 +1,4 @@
-import { Model, initAccelRecord } from "accel-record-core";
+import { Model, initAccelRecord } from "accel-record";
 import { dbConfig } from "../vitest.setup";
 
 describe("initAccelRecord", () => {

--- a/tests/models/transaction.test-d.ts
+++ b/tests/models/transaction.test-d.ts
@@ -10,4 +10,14 @@ describe("Transaction", () => {
     const result2 = Model.transaction(() => 12345);
     expectTypeOf(result2).toEqualTypeOf<number | undefined>();
   });
+
+  test(".transaction() with Promise", async () => {
+    const result = await Model.transaction(async () => {
+      return "ok";
+    });
+    expectTypeOf(result).toEqualTypeOf<string | undefined>();
+
+    const result2 = await Model.transaction(async () => 12345);
+    expectTypeOf(result2).toEqualTypeOf<number | undefined>();
+  });
 });

--- a/tests/models/transaction.test-d.ts
+++ b/tests/models/transaction.test-d.ts
@@ -1,4 +1,4 @@
-import { Model } from "accel-record-core";
+import { Model } from "accel-record";
 
 describe("Transaction", () => {
   test(".transaction()", () => {

--- a/tests/models/transaction.test-d.ts
+++ b/tests/models/transaction.test-d.ts
@@ -2,13 +2,26 @@ import { Model } from "accel-record";
 
 describe("Transaction", () => {
   test(".transaction()", () => {
-    const result = Model.transaction(() => {
-      return "foo";
-    });
-    expectTypeOf(result).toEqualTypeOf<string | undefined>();
-
-    const result2 = Model.transaction(() => 12345);
-    expectTypeOf(result2).toEqualTypeOf<number | undefined>();
+    {
+      const result = Model.transaction(() => {});
+      expectTypeOf(result).toEqualTypeOf<void | undefined>();
+    }
+    {
+      const result = Model.transaction(() => {
+        throw new Error("error");
+      });
+      expectTypeOf(result).toEqualTypeOf<undefined>();
+    }
+    {
+      const result = Model.transaction(() => {
+        return "foo";
+      });
+      expectTypeOf(result).toEqualTypeOf<string | undefined>();
+    }
+    {
+      const result = Model.transaction(() => 12345);
+      expectTypeOf(result).toEqualTypeOf<number | undefined>();
+    }
   });
 
   test(".transaction() with Promise", async () => {

--- a/tests/models/transaction.test-d.ts
+++ b/tests/models/transaction.test-d.ts
@@ -1,0 +1,13 @@
+import { Model } from "accel-record-core";
+
+describe("Transaction", () => {
+  test(".transaction()", () => {
+    const result = Model.transaction(() => {
+      return "foo";
+    });
+    expectTypeOf(result).toEqualTypeOf<string | undefined>();
+
+    const result2 = Model.transaction(() => 12345);
+    expectTypeOf(result2).toEqualTypeOf<number | undefined>();
+  });
+});

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -11,6 +11,20 @@ describe("Transaction", () => {
     });
     expect(User.all().toArray()).toHaveLength(0);
   });
+
+  test(".transaction() with Promise", async () => {
+    const result = await Model.transaction(async () => {
+      return "ok";
+    });
+    expect(result).toBe("ok");
+  });
+
+  test(".transaction() with Rollback in Promise", async () => {
+    const result = await Model.transaction(async () => {
+      throw new Rollback();
+    });
+    expect(result).toBe(undefined);
+  });
 });
 
 describe("nested Transaction", () => {

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -15,7 +15,7 @@ describe("Transaction", () => {
 
 describe("nested Transaction", () => {
   test("commited, rollbacked ", () => {
-    Model.transaction(() => {
+    const result = Model.transaction(() => {
       $user.create({ name: "hoge" });
       expect(User.count()).toBe(1);
 
@@ -25,12 +25,15 @@ describe("nested Transaction", () => {
         throw new Rollback();
       });
       expect(User.count()).toBe(1);
+
+      return true;
     }); // commited
+    expect(result).toBe(true);
     expect(User.count()).toBe(1);
   });
 
   test("rollbacked, rollbacked", () => {
-    Model.transaction(() => {
+    const result = Model.transaction(() => {
       $user.create({ name: "hoge" });
       expect(User.count()).toBe(1);
 
@@ -42,6 +45,7 @@ describe("nested Transaction", () => {
       expect(User.count()).toBe(1);
       throw new Rollback();
     }); // rollbacked
+    expect(result).toBe(undefined);
     expect(User.count()).toBe(0);
   });
 

--- a/tests/models/transaction.test.ts
+++ b/tests/models/transaction.test.ts
@@ -1,4 +1,4 @@
-import { Model, Rollback } from "accel-record-core";
+import { Model, Rollback } from "accel-record";
 import { $user } from "../factories/user";
 import { User } from "./index.js";
 


### PR DESCRIPTION
Transaction improvement
- returning the result of the callback
- supporting asynchronous callbacks
- mod README

```ts
const result = await Model.transaction(async () => {
  return "ok";
});
expectTypeOf(result).toEqualTypeOf<string | undefined>();
```