### PR TITLE
Password Authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "packages/prisma-generator-accel-record"
       ],
       "dependencies": {
-        "@prisma/client": "^5.9.1"
+        "@prisma/client": "^5.9.1",
+        "bcrypt-ts": "^5.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.19",
@@ -887,6 +888,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcrypt-ts": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-ts/-/bcrypt-ts-5.0.2.tgz",
+      "integrity": "sha512-gDwQ5784AkkfhHACh3jGcg1hUubyZyeq9AtVd5gXkcyHGVOC+mORjRIHSj+fHfqwY5vxwyBLXQpcfk8MpK0ROg==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/better-sqlite3": {
       "version": "9.4.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "vitest": "^1.3.0"
   },
   "dependencies": {
-    "@prisma/client": "^5.9.1"
+    "@prisma/client": "^5.9.1",
+    "bcrypt-ts": "^5.0.2"
   }
 }

--- a/packages/accel-record-core/src/associations/modelInstanceBuilder.ts
+++ b/packages/accel-record-core/src/associations/modelInstanceBuilder.ts
@@ -19,11 +19,12 @@ export class ModelInstanceBuilder {
       }
     }
     this.initAssociations<T>(klass, instance);
-    for (const key of instance.associations.keys()) {
-      if (key in input) {
+    // Updating fields other than the column field
+    Object.keys(input).forEach((key) => {
+      if (klass.attributeToColumn(key) == undefined) {
         proxy[key] = input[key];
       }
-    }
+    });
     return proxy;
   }
 

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -31,6 +31,7 @@ export { Rollback } from "./transaction.js";
 export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
 export { before, after } from "./callbacks.js";
+export { hasSecurePassword } from "./model/securePassword.js";
 
 export { classIncludes as Mix };
 

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -16,7 +16,7 @@ import { Validations } from "./model/validations.js";
 import { Persistence } from "./persistence.js";
 import { Query } from "./query.js";
 import { Transaction } from "./transaction.js";
-import { classIncludes } from "./utils.js";
+import { Mix } from "./utils.js";
 
 export { Collection } from "./associations/collectionProxy.js";
 export {
@@ -33,7 +33,7 @@ export { Validator } from "./validation/validator/index.js";
 export { before, after } from "./callbacks.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 
-export { classIncludes as Mix };
+export { Mix };
 
 export type Meta<T> = ReturnType<typeof meta<T>>;
 
@@ -60,7 +60,7 @@ export const registerModel = (model: any) => {
   Models[model.name] = model;
 };
 
-export class Model extends classIncludes(
+export class Model extends Mix(
   AttributeAssignment,
   Callbacks,
   Connection,

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -57,7 +57,6 @@ export const registerModel = (model: any) => {
   Models[model.name] = model;
 };
 
-// @ts-ignore
 export class Model extends classIncludes(
   AttributeAssignment,
   Callbacks,

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -32,7 +32,7 @@ export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
 export { before, after } from "./callbacks.js";
 
-export { classIncludes as mixin };
+export { classIncludes as Mix };
 
 export type Meta<T> = ReturnType<typeof meta<T>>;
 

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -32,6 +32,8 @@ export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
 export { before, after } from "./callbacks.js";
 
+export { classIncludes as mixin };
+
 export type Meta<T> = ReturnType<typeof meta<T>>;
 
 export declare function meta<T>(model: T): ModelMeta;

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -1,16 +1,21 @@
 import { Model } from "../index.js";
 
-export const hasSecurePassword = () => {
+export const hasSecurePassword = (
+  options: { attribute?: string; validations?: boolean } = {}
+) => {
+  const attribute = options.attribute ?? "password";
+  const confirmAttribute = `${attribute}Confirmation`;
+  const validations = options.validations ?? true;
   let _password: string | undefined = undefined;
   let _passwordConfirmation: string | undefined = undefined;
   return class SecurePassword {
-    get password() {
+    get [attribute]() {
       return _password;
     }
-    set password(value: string | undefined) {
+    set [attribute](value: string | undefined) {
       _password = value;
     }
-    set passwordConfirmation(value: string) {
+    set [confirmAttribute](value: string) {
       _passwordConfirmation = value;
     }
     authenticate<T extends Model>(this: T, password: string): false | T {
@@ -21,9 +26,10 @@ export const hasSecurePassword = () => {
       }
     }
     validateAttributes<T extends Model & { password: string }>(this: T) {
-      this.validates("password", { presence: true });
+      if (!validations) return;
+      this.validates(attribute as any, { presence: true });
       if (_password !== _passwordConfirmation) {
-        this.errors.add("passwordConfirmation", "does not match password");
+        this.errors.add(confirmAttribute, `does not match ${attribute}`);
       }
     }
   };

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -28,15 +28,21 @@ export function hasSecurePassword<T extends string = "password">(
       return this._password;
     }
     set [attribute](value: string | undefined) {
-      (this as any)[`${attribute}Digest`] =
+      this.digest =
         value == undefined ? undefined : hashSync(value, genSaltSync());
       this._password = value;
     }
     set [confirmAttribute](value: string) {
       this._passwordConfirmation = value;
     }
+    private get digest() {
+      return (this as any)[`${attribute}Digest`] as string | undefined;
+    }
+    private set digest(value: string | undefined) {
+      (this as any)[`${attribute}Digest`] = value;
+    }
     authenticate<T extends Model & SecurePassword>(this: T, password: string) {
-      return compareSync(password, (this as any)[`${attribute}Digest`]);
+      return this.digest ? compareSync(password, this.digest) : false;
     }
     validateAttributes<T extends Model & SecurePassword>(this: T) {
       if (!validations) return;

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -1,15 +1,38 @@
 import { Model } from "../index.js";
 import { compareSync, genSaltSync, hashSync } from "bcrypt-ts";
 
+/**
+ * Represents a secure password type.
+ * @template T - The type of the password.
+ */
 type SecurePassword<T extends string> = {
   new (): {
     [K in T | `${T}Confirmation`]: string | undefined;
   } & {
+    /**
+     * Authenticates the model instance by comparing the provided password with the stored digest.
+     * Returns true if the password matches the digest, false otherwise.
+     * @param password - The password to compare with the stored digest.
+     * @returns A boolean indicating whether the password matches the stored digest.
+     */
     authenticate<M extends Model>(this: M, password: string): boolean;
+
+    /**
+     * Validates the attributes of the secure password.
+     */
     validateAttributes(): void;
   };
 };
 
+/**
+ * Creates a class that represents a secure password.
+ * @param options.attribute - The name of the password attribute. Default is "password".
+ * @param options.validations - Indicates whether to perform validations. Default is true.
+ * @returns The class representing a secure password.
+ *
+ * @example hasSecurePassword()
+ * @example hasSecurePassword({ attribute: "recovery", validations: false })
+ */
 export function hasSecurePassword<T extends string = "password">(
   options: {
     attribute?: T;

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -1,0 +1,30 @@
+import { Model } from "../index.js";
+
+export const hasSecurePassword = () => {
+  let _password: string | undefined = undefined;
+  let _passwordConfirmation: string | undefined = undefined;
+  return class SecurePassword {
+    get password() {
+      return _password;
+    }
+    set password(value: string | undefined) {
+      _password = value;
+    }
+    set passwordConfirmation(value: string) {
+      _passwordConfirmation = value;
+    }
+    authenticate<T extends Model>(this: T, password: string): false | T {
+      if (password === _password) {
+        return this;
+      } else {
+        return false;
+      }
+    }
+    validateAttributes<T extends Model & { password: string }>(this: T) {
+      this.validates("password", { presence: true });
+      if (_password !== _passwordConfirmation) {
+        this.errors.add("passwordConfirmation", "does not match password");
+      }
+    }
+  };
+};

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -1,36 +1,53 @@
 import { Model } from "../index.js";
 
-export const hasSecurePassword = (
-  options: { attribute?: string; validations?: boolean } = {}
-) => {
+type SecurePassword<T extends string> = {
+  new (): {
+    [K in T | `${T}Confirmation`]: string | undefined;
+  } & {
+    authenticate<M extends Model>(this: M, password: string): false | M;
+    validateAttributes(): void;
+  };
+};
+
+export function hasSecurePassword<T extends string = "password">(
+  options: {
+    attribute?: T;
+    validations?: boolean;
+  } = {}
+): SecurePassword<T> {
   const attribute = options.attribute ?? "password";
   const confirmAttribute = `${attribute}Confirmation`;
   const validations = options.validations ?? true;
-  let _password: string | undefined = undefined;
-  let _passwordConfirmation: string | undefined = undefined;
+  // @ts-ignore
   return class SecurePassword {
+    private _password: string | undefined;
+    private _passwordConfirmation: string | undefined;
+
     get [attribute]() {
-      return _password;
+      return this._password;
     }
     set [attribute](value: string | undefined) {
-      _password = value;
+      this._password = value;
     }
     set [confirmAttribute](value: string) {
-      _passwordConfirmation = value;
+      this._passwordConfirmation = value;
     }
-    authenticate<T extends Model>(this: T, password: string): false | T {
-      if (password === _password) {
+    authenticate<T extends Model & SecurePassword>(
+      this: T,
+      password: string
+    ): false | T {
+      if (password === this._password) {
         return this;
       } else {
         return false;
       }
     }
-    validateAttributes<T extends Model & { password: string }>(this: T) {
+    validateAttributes<T extends Model & SecurePassword>(this: T) {
       if (!validations) return;
       this.validates(attribute as any, { presence: true });
-      if (_password !== _passwordConfirmation) {
+      if (this._password !== this._passwordConfirmation) {
         this.errors.add(confirmAttribute, `does not match ${attribute}`);
       }
     }
   };
-};
+}

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -46,6 +46,11 @@ export function hasSecurePassword<T extends string = "password">(
     }
     validateAttributes<T extends Model & SecurePassword>(this: T) {
       if (!validations) return;
+      if (
+        this._password == undefined &&
+        this._passwordConfirmation == undefined
+      )
+        return;
       this.validates(attribute as any, { presence: true });
       if (this._password !== this._passwordConfirmation) {
         this.errors.add(confirmAttribute, `does not match ${attribute}`);

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -16,7 +16,6 @@ export type Relations<T, M extends ModelMeta> =
   | Relation<T, M>
   | Collection<T extends Model ? T : any, M>;
 
-// @ts-ignore
 export class Relation<T, M extends ModelMeta> extends classIncludes(
   Association,
   Batches,

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -1,7 +1,7 @@
 import { Collection, Model } from "../index.js";
 import { type ModelMeta } from "../meta.js";
 import { ToHashOptions, ToHashResult } from "../model/serialization.js";
-import { classIncludes } from "../utils.js";
+import { Mix } from "../utils.js";
 import { Association } from "./association.js";
 import { RelationBase } from "./base.js";
 import { Batches } from "./batches.js";
@@ -16,7 +16,7 @@ export type Relations<T, M extends ModelMeta> =
   | Relation<T, M>
   | Collection<T extends Model ? T : any, M>;
 
-export class Relation<T, M extends ModelMeta> extends classIncludes(
+export class Relation<T, M extends ModelMeta> extends Mix(
   Association,
   Batches,
   Calculations,

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -45,7 +45,14 @@ export const classIncludes = <T extends (new (...args: any) => any)[]>(
 
 const assign = (target: object, source: object, key: string) => {
   const desc = Object.getOwnPropertyDescriptor(source, key);
-  const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+
+  let targetDesc = Object.getOwnPropertyDescriptor(target, key);
+  let proto = Object.getPrototypeOf(target);
+
+  while (!targetDesc && proto && proto !== Object.prototype) {
+    targetDesc = Object.getOwnPropertyDescriptor(proto, key);
+    proto = Object.getPrototypeOf(proto);
+  }
   if (
     typeof targetDesc?.value == "function" &&
     typeof desc?.value == "function"

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -65,7 +65,7 @@ const assign = (target: object, source: object, key: string) => {
     Object.defineProperty(target, key, {
       value: function (this: any, ...args: any[]) {
         targetDesc.value.apply(this, args);
-        desc.value.apply(this, args);
+        return desc.value.apply(this, args);
       },
     });
   } else if (desc) {

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -91,6 +91,9 @@ const assign = (target: object, source: object, key: string) => {
         targetDesc.value.apply(this, args);
         return desc.value.apply(this, args);
       },
+      enumerable: targetDesc.enumerable,
+      writable: true,
+      configurable: true,
     });
   } else if (desc) {
     Object.defineProperty(target, key, desc);

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -42,7 +42,19 @@ export const classIncludes = <T extends (new (...args: any) => any)[]>(
 
 const assign = (target: object, source: object, key: string) => {
   const desc = Object.getOwnPropertyDescriptor(source, key);
-  if (desc) {
+  const targetDesc = Object.getOwnPropertyDescriptor(target, key);
+  if (
+    typeof targetDesc?.value == "function" &&
+    typeof desc?.value == "function"
+  ) {
+    // already has a method, so we need to wrap it
+    Object.defineProperty(target, key, {
+      value: function (this: any, ...args: any[]) {
+        targetDesc.value.apply(this, args);
+        desc.value.apply(this, args);
+      },
+    });
+  } else if (desc) {
     Object.defineProperty(target, key, desc);
   }
 };

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -1,3 +1,7 @@
+type WithoutConstructor<T> = {
+  [P in keyof T]: T[P];
+};
+
 type InstanceTypeIntersection<T extends any[]> = T extends [
   infer Head extends abstract new (...args: any) => any,
   ...infer Tail extends (abstract new (...args: any) => any)[],
@@ -9,7 +13,7 @@ type ObjectIntersection<T extends any[]> = T extends [
   infer Head extends abstract new (...args: any) => any,
   ...infer Tail extends (abstract new (...args: any) => any)[],
 ]
-  ? Head & ObjectIntersection<Tail>
+  ? WithoutConstructor<Head> & ObjectIntersection<Tail>
   : {};
 
 export const classIncludes = <T extends (new (...args: any) => any)[]>(

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -43,16 +43,20 @@ export const classIncludes = <T extends (new (...args: any) => any)[]>(
   return newClass;
 };
 
-const assign = (target: object, source: object, key: string) => {
-  const desc = Object.getOwnPropertyDescriptor(source, key);
-
-  let targetDesc = Object.getOwnPropertyDescriptor(target, key);
-  let proto = Object.getPrototypeOf(target);
-
-  while (!targetDesc && proto && proto !== Object.prototype) {
-    targetDesc = Object.getOwnPropertyDescriptor(proto, key);
+const findMethod = (target: object, key: string) => {
+  let proto = target;
+  while (proto && proto !== Object.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(proto, key);
+    if (desc) return desc;
     proto = Object.getPrototypeOf(proto);
   }
+  return undefined;
+};
+
+const assign = (target: object, source: object, key: string) => {
+  const desc = Object.getOwnPropertyDescriptor(source, key);
+  const targetDesc = findMethod(target, key);
+
   if (
     typeof targetDesc?.value == "function" &&
     typeof desc?.value == "function"

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -19,21 +19,24 @@ type ObjectIntersection<T extends any[]> = T extends [
 export const classIncludes = <T extends (new (...args: any) => any)[]>(
   ...args: T
 ): { new (): InstanceTypeIntersection<T> } & ObjectIntersection<T> => {
-  const newClass: any = class {
+  const BaseClass = args[0];
+  const klassList = args.slice(1);
+  const newClass: any = class extends BaseClass {
     constructor() {
-      for (const arg of args) {
-        const obj = new arg();
+      super();
+      for (const klass of klassList) {
+        const obj = new klass();
         for (const key of Object.getOwnPropertyNames(obj)) {
           assign(this, obj, key);
         }
       }
     }
   };
-  for (let arg of args) {
-    getStaticProperties(arg).forEach((klass, key) => {
+  for (let klass of klassList) {
+    getStaticProperties(klass).forEach((klass, key) => {
       assign(newClass, klass, key);
     });
-    getInstanceMethods(arg).forEach((proto, key) => {
+    getInstanceMethods(klass).forEach((proto, key) => {
       assign(newClass.prototype, proto, key);
     });
   }

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -34,6 +34,7 @@ It can be used with MySQL, PostgreSQL, and SQLite.
 - [Bulk Insert](#bulk-insert)
 - [Transactions](#transactions)
 - [Internationalization (I18n)](#internationalization-i18n)
+- [Password Authentication](#password-authentication)
 - [Nullable Values Handling](#nullable-values-handling)
 - [Future Planned Features](#future-planned-features)
 
@@ -1170,6 +1171,61 @@ The message keys corresponding to each validation are as follows:
 
 For those with interpolation set to `count`, that part will be replaced with the value specified in the option when the error message contains `%{count}`.
 
+## Password Authentication
+
+We provide a mechanism for securely hashing and authenticating passwords using Bcrypt.
+
+First, add a `passwordDigest` field to the model to store the hashed password.
+
+```ts
+// prisma/schema.prisma
+model User {
+  ...
+  passwordDigest String // Stores the hash value of the password
+}
+```
+
+Next, use `hasSecurePassword()` to add functionality to the model for hashing and authenticating passwords.
+
+```ts
+// ./models/user.ts
+import { hasSecurePassword, Mix } from "accel-record";
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class UserModel extends Mix(ApplicationRecord, hasSecurePassword()) {}
+```
+
+With this, you can perform password validation and hashing using the `password` and `passwordConfirmation` fields, and authenticate passwords using the `authenticate()` method.
+
+```ts
+import { User } from "./models/index.js";
+
+const user = User.build({});
+user.password = "";
+user.save(); // => false (password can't be blank)
+user.password = "myPassword";
+user.save(); // => false (password confirmation doesn't match)
+user.passwordConfirmation = "myPassword";
+user.save(); // => true
+
+user.authenticate("invalid"); // => false
+user.authenticate("myPassword"); // => true
+```
+
+You can customize the field name for storing the password by setting it to something other than `passwordDigest`, and you can manage multiple passwords in the model as well.
+
+```ts
+// ./models/user.ts
+import { hasSecurePassword, Mix } from "accel-record";
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class UserModel extends Mix(
+  ApplicationRecord,
+  hasSecurePassword(), // Uses the passwordDigest field
+  hasSecurePassword({ attribute: "recovery", validation: false }) // Uses the recoveryDigest field
+) {}
+```
+
 ## Nullable Values Handling
 
 Regarding nullable values, TypeScript, like JavaScript, has two options: undefined and null. \
@@ -1197,7 +1253,6 @@ user.update({ age: undefined });
 ## Future Planned Features
 
 - [accel-record-core] Scopes
-- [accel-record-core] Authentication
 - [accel-record-core] Support for Composite IDs
 - [accel-record-core] Expansion of Query Interface
 

--- a/packages/prisma-generator-accel-record/src/generators/applicationRecord.ts
+++ b/packages/prisma-generator-accel-record/src/generators/applicationRecord.ts
@@ -16,8 +16,8 @@ export const ensureApplicationRecord = async (options: GeneratorOptions) => {
 const generateApplicationRecord = () => {
   return `import { Model } from "accel-record";
 
-export abstract class ApplicationRecord extends Model {
-  // Implement abstract methods
+export class ApplicationRecord extends Model {
+  // Implement methods
 }
 `;
 };

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -147,6 +147,13 @@ declare module "accel-record" {
           field.type == "Json"
             ? `${model.baseModel}["${field.name}"]`
             : `${field.typeName}${field.isList ? "[]" : ""}`;
+        if (field.name.endsWith("Digest") && field.type == "String") {
+          return [
+            `    ${field.name}${optional ? "?" : ""}: string;`,
+            `    ${field.name.replace("Digest", "")}?: string;`,
+            `    ${field.name.replace("Digest", "Confirmation")}?: string;`,
+          ].join("\n");
+        }
         return `    ${field.name}${optional ? "?" : ""}: ${valType};`;
       })
       .join("\n");

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -130,33 +130,6 @@ declare module "accel-record" {
   data += enumData(options);
   for (const _model of options.dmmf.datamodel.models) {
     const model = new ModelWrapper(_model, options.dmmf.datamodel);
-    const reject = (f: FieldWrapper) => f.relationFromFields?.[0] == undefined;
-    const relationFromFields = model.fields
-      .flatMap((f) => f.relationFromFields)
-      .filter((f) => f != undefined);
-    const columns = model.fields
-      .filter(reject)
-      .filter((f) => !relationFromFields.includes(f.name))
-      .map((field) => {
-        const optional =
-          field.hasDefaultValue ||
-          !field.isRequired ||
-          field.isList ||
-          field.isUpdatedAt;
-        const valType =
-          field.type == "Json"
-            ? `${model.baseModel}["${field.name}"]`
-            : `${field.typeName}${field.isList ? "[]" : ""}`;
-        if (field.name.endsWith("Digest") && field.type == "String") {
-          return [
-            `    ${field.name}${optional ? "?" : ""}: string;`,
-            `    ${field.name.replace("Digest", "")}?: string;`,
-            `    ${field.name.replace("Digest", "Confirmation")}?: string;`,
-          ].join("\n");
-        }
-        return `    ${field.name}${optional ? "?" : ""}: ${valType};`;
-      })
-      .join("\n");
     const associationColumns = model.fields
       .filter((f) => f.relationName && (f.relationFromFields?.length ?? 0) > 0)
       .map((f) => {
@@ -183,9 +156,7 @@ type ${model.meta} = {
   Persisted: ${model.persistedModel};
   AssociationKey: ${associationKey(model)};
   Column: {${columnMeta(model)}};
-  CreateInput: {
-${columns}
-  }${associationColumns};
+  CreateInput: {${createInputs(model)}}${associationColumns};
   WhereInput: {${whereInputs(model)}};
 };
 registerModel(${model.persistedModel});
@@ -296,6 +267,37 @@ const columnMeta = (model: ModelWrapper) =>
         };`
     )
     .join("") + "\n  ";
+
+const createInputs = (model: ModelWrapper) => {
+  const relationFromFields = model.fields
+    .flatMap((f) => f.relationFromFields)
+    .filter((f) => f != undefined);
+  return (
+    model.fields
+      .filter((f) => f.relationFromFields?.[0] == undefined)
+      .filter((f) => !relationFromFields.includes(f.name))
+      .map((field) => {
+        const optional =
+          field.hasDefaultValue ||
+          !field.isRequired ||
+          field.isList ||
+          field.isUpdatedAt;
+        const valType =
+          field.type == "Json"
+            ? `${model.baseModel}["${field.name}"]`
+            : `${field.typeName}${field.isList ? "[]" : ""}`;
+        if (field.name.endsWith("Digest") && field.type == "String") {
+          return [
+            `\n    ${field.name}${optional ? "?" : ""}: string;`,
+            `\n    ${field.name.replace("Digest", "")}?: string;`,
+            `\n    ${field.name.replace("Digest", "Confirmation")}?: string;`,
+          ].join("");
+        }
+        return `\n    ${field.name}${optional ? "?" : ""}: ${valType};`;
+      })
+      .join("") + "\n  "
+  );
+};
 
 const whereInputs = (model: ModelWrapper) =>
   model.fields

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -98,6 +98,8 @@ type UserMeta = {
     id?: number;
     email: string;
     passwordDigest?: string;
+    password?: string;
+    passwordConfirmation?: string;
     name?: string;
     age?: number;
     posts?: PostModel[];

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -50,6 +50,7 @@ declare module "./user" {
   interface UserModel {
     id: number | undefined;
     email: string | undefined;
+    passwordDigest: string | undefined;
     name: string | undefined;
     age: number | undefined;
     get posts(): PostCollection<PostModel>;
@@ -87,6 +88,7 @@ type UserMeta = {
   Column: {
     id: number;
     email: string;
+    passwordDigest: string | undefined;
     name: string | undefined;
     age: number | undefined;
     createdAt: Date;
@@ -95,6 +97,7 @@ type UserMeta = {
   CreateInput: {
     id?: number;
     email: string;
+    passwordDigest?: string;
     name?: string;
     age?: number;
     posts?: PostModel[];
@@ -107,6 +110,7 @@ type UserMeta = {
   WhereInput: {
     id?: number | number[] | Filter<number> | null;
     email?: string | string[] | StringFilter | null;
+    passwordDigest?: string | string[] | StringFilter | null;
     name?: string | string[] | StringFilter | null;
     age?: number | number[] | Filter<number> | null;
     createdAt?: Date | Date[] | Filter<Date> | null;

--- a/tests/models/applicationRecord.ts
+++ b/tests/models/applicationRecord.ts
@@ -1,5 +1,5 @@
 import { Model } from "accel-record-core";
 
-export abstract class ApplicationRecord extends Model {
+export class ApplicationRecord extends Model {
   // Implement abstract methods
 }

--- a/tests/models/mix.test.ts
+++ b/tests/models/mix.test.ts
@@ -12,6 +12,8 @@ class A {
 
   validate() {
     this.errors.push("a");
+
+    return false;
   }
 }
 
@@ -26,6 +28,8 @@ class C {
 
   validate<T extends A>(this: T) {
     this.errors.push("c");
+
+    return true;
   }
 }
 
@@ -48,8 +52,8 @@ test("mix", () => {
   expect(abc.aa).toBe("aa");
   expect(abc instanceof A).toBe(true);
 
-  ab.validate();
+  expect(ab.validate()).toBe(false);
   expect(ab.errors).toEqual(["a"]);
-  abc.validate();
+  expect(abc.validate()).toBe(true);
   expect(abc.errors).toEqual(["a", "c"]);
 });

--- a/tests/models/mix.test.ts
+++ b/tests/models/mix.test.ts
@@ -1,0 +1,39 @@
+import { Mix } from "accel-record-core";
+
+class A {
+  static a = "a";
+
+  a = "a";
+
+  get aa() {
+    return "aa";
+  }
+}
+
+class B {}
+
+class AB extends Mix(A, B) {}
+
+class C {
+  static c = "c";
+
+  c = "c";
+}
+
+class ABC extends Mix(AB, C) {}
+
+test("mix", () => {
+  expect(AB.a).toBe("a");
+
+  expect(ABC.a).toBe("a");
+  expect(ABC.c).toBe("c");
+
+  const ab = new AB();
+  expect(ab.a).toBe("a");
+  expect(ab.aa).toBe("aa");
+
+  const abc = new ABC();
+  expect(abc.a).toBe("a");
+  expect(abc.c).toBe("c");
+  expect(abc.aa).toBe("aa");
+});

--- a/tests/models/mix.test.ts
+++ b/tests/models/mix.test.ts
@@ -4,9 +4,14 @@ class A {
   static a = "a";
 
   a = "a";
+  errors: string[] = [];
 
   get aa() {
     return "aa";
+  }
+
+  validate() {
+    this.errors.push("a");
   }
 }
 
@@ -18,6 +23,10 @@ class C {
   static c = "c";
 
   c = "c";
+
+  validate<T extends A>(this: T) {
+    this.errors.push("c");
+  }
 }
 
 class ABC extends Mix(AB, C) {}
@@ -36,4 +45,9 @@ test("mix", () => {
   expect(abc.a).toBe("a");
   expect(abc.c).toBe("c");
   expect(abc.aa).toBe("aa");
+
+  ab.validate();
+  expect(ab.errors).toEqual(["a"]);
+  abc.validate();
+  expect(abc.errors).toEqual(["a", "c"]);
 });

--- a/tests/models/mix.test.ts
+++ b/tests/models/mix.test.ts
@@ -40,11 +40,13 @@ test("mix", () => {
   const ab = new AB();
   expect(ab.a).toBe("a");
   expect(ab.aa).toBe("aa");
+  expect(ab instanceof A).toBe(true);
 
   const abc = new ABC();
   expect(abc.a).toBe("a");
   expect(abc.c).toBe("c");
   expect(abc.aa).toBe("aa");
+  expect(abc instanceof A).toBe(true);
 
   ab.validate();
   expect(ab.errors).toEqual(["a"]);

--- a/tests/models/model/securePassword.test-d.ts
+++ b/tests/models/model/securePassword.test-d.ts
@@ -8,6 +8,9 @@ test("hasSecurePassword()", () => {
   user.passwordConfirmation = "";
   expectTypeOf(user.authenticate("")).toBeBoolean();
   expectTypeOf(user.authenticatePassword("")).toBeBoolean();
+
+  // @ts-expect-error
+  user.hoge;
 });
 
 test("hasSecurePassword() with custom attribute", () => {

--- a/tests/models/model/securePassword.test-d.ts
+++ b/tests/models/model/securePassword.test-d.ts
@@ -1,0 +1,42 @@
+import { hasSecurePassword, Mix } from "accel-record-core";
+import { $user } from "../../factories/user";
+import { ApplicationRecord } from "../applicationRecord";
+
+test("hasSecurePassword()", () => {
+  const user = $user.create();
+  user.password = "";
+  user.passwordConfirmation = "";
+  expectTypeOf(user.authenticate("")).toBeBoolean();
+  expectTypeOf(user.authenticatePassword("")).toBeBoolean();
+});
+
+test("hasSecurePassword() with custom attribute", () => {
+  class CustomAttributeUser extends Mix(
+    ApplicationRecord,
+    hasSecurePassword({ attribute: "recovery" })
+  ) {}
+  const user = new CustomAttributeUser();
+  user.recovery = "";
+  user.recoveryConfirmation = "";
+  expectTypeOf(user.authenticateRecovery("")).toBeBoolean();
+  // @ts-expect-error
+  user.authenticate("");
+  // @ts-expect-error
+  user.authenticatePassword("");
+});
+
+test("hasSecurePassword() multiple", () => {
+  class MultiplePasswordUser extends Mix(
+    ApplicationRecord,
+    hasSecurePassword(),
+    hasSecurePassword({ attribute: "recovery", validations: false })
+  ) {}
+  const user = new MultiplePasswordUser();
+  user.password = "";
+  user.passwordConfirmation = "";
+  user.recovery = "";
+  user.recoveryConfirmation = "";
+  expectTypeOf(user.authenticate("")).toBeBoolean();
+  expectTypeOf(user.authenticatePassword("")).toBeBoolean();
+  expectTypeOf(user.authenticateRecovery("")).toBeBoolean();
+});

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -1,0 +1,22 @@
+import { User } from "..";
+import { $user } from "../../factories/user";
+
+test("hasSecurePassword()", () => {
+  const user = $user.build({ name: "david" });
+  user.password = "";
+  user.passwordConfirmation = "nomatch";
+  expect(user.save()).toBe(false); // password required
+  user.password = "mUc3m00RsqyRe";
+  expect(user.save()).toBe(false); // confirmation doesn't match
+  user.passwordConfirmation = "mUc3m00RsqyRe";
+  expect(user.save()).toBe(true);
+  // user.recovery_password = "42password"
+  // user.recovery_password_digest                              #=> "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
+  // user.save                                                  #=> true
+
+  expect(user.authenticate("notright")).toBe(false);
+  expect(user.authenticate("mUc3m00RsqyRe")).toBe(user);
+
+  User.findBy({ name: "david" })?.authenticate("notright"); //=> false
+  User.findBy({ name: "david" })?.authenticate("mUc3m00RsqyRe"); //=> user
+});

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -12,15 +12,18 @@ test("hasSecurePassword()", () => {
   expect(user.save()).toBe(false); // confirmation doesn't match
   user.passwordConfirmation = "mUc3m00RsqyRe";
   expect(user.save()).toBe(true);
+
+  expect(user.passwordDigest).not.toBeUndefined();
   // user.recovery_password = "42password"
   // user.recovery_password_digest                              #=> "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
   // user.save                                                  #=> true
 
   expect(user.authenticate("notright")).toBe(false);
-  expect(user.authenticate("mUc3m00RsqyRe")).toBe(user);
+  expect(user.authenticate("mUc3m00RsqyRe")).toBe(true);
 
-  User.findBy({ name: "david" })?.authenticate("notright"); //=> false
-  User.findBy({ name: "david" })?.authenticate("mUc3m00RsqyRe"); //=> user
+  const u = User.find(user.id!);
+  expect(u.authenticate("notright")).toBe(false);
+  expect(u.authenticate("mUc3m00RsqyRe")).toBe(true);
 
   // @ts-expect-error
   user.hoge;

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -4,26 +4,30 @@ import { $user } from "../../factories/user";
 import { ApplicationRecord } from "../applicationRecord";
 
 test("hasSecurePassword()", () => {
-  const user = $user.build({ name: "david" });
+  const user = $user.build({});
   user.password = "";
-  user.passwordConfirmation = "nomatch";
-  expect(user.save()).toBe(false); // password required
-  user.password = "mUc3m00RsqyRe";
-  expect(user.save()).toBe(false); // confirmation doesn't match
-  user.passwordConfirmation = "mUc3m00RsqyRe";
+  user.passwordConfirmation = "";
+  expect(user.save()).toBe(false);
+  expect(user.errors.fullMessages).toEqual(["Password can't be blank"]);
+
+  user.password = "xBOHdowK5e2YjQ1s";
+  expect(user.save()).toBe(false);
+  expect(user.errors.fullMessages).toEqual([
+    "PasswordConfirmation does not match password",
+  ]);
+
+  user.passwordConfirmation = "xBOHdowK5e2YjQ1s";
   expect(user.save()).toBe(true);
+  expect(user.errors.fullMessages).toEqual([]);
 
   expect(user.passwordDigest).not.toBeUndefined();
-  // user.recovery_password = "42password"
-  // user.recovery_password_digest                              #=> "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
-  // user.save                                                  #=> true
 
-  expect(user.authenticate("notright")).toBe(false);
-  expect(user.authenticate("mUc3m00RsqyRe")).toBe(true);
+  expect(user.authenticate("invalid")).toBe(false);
+  expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
 
   const u = User.find(user.id!);
-  expect(u.authenticate("notright")).toBe(false);
-  expect(u.authenticate("mUc3m00RsqyRe")).toBe(true);
+  expect(u.authenticate("invalid")).toBe(false);
+  expect(u.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
 
   // @ts-expect-error
   user.hoge;
@@ -45,6 +49,6 @@ test("hasSecurePassword() with custom attribute", () => {
     hasSecurePassword({ attribute: "recovery" })
   ) {}
   const user = new CustomAttributeUser();
-  user.recovery = user.recoveryConfirmation = "mUc3m00RsqyRe";
+  user.recovery = user.recoveryConfirmation = "xBOHdowK5e2YjQ1s";
   expect(user.isValid()).toBe(true);
 });

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -1,5 +1,7 @@
+import { hasSecurePassword, Mix } from "accel-record-core";
 import { User } from "..";
 import { $user } from "../../factories/user";
+import { ApplicationRecord } from "../applicationRecord";
 
 test("hasSecurePassword()", () => {
   const user = $user.build({ name: "david" });
@@ -19,4 +21,28 @@ test("hasSecurePassword()", () => {
 
   User.findBy({ name: "david" })?.authenticate("notright"); //=> false
   User.findBy({ name: "david" })?.authenticate("mUc3m00RsqyRe"); //=> user
+});
+
+test("hasSecurePassword() with validations: false", () => {
+  class NoValidationsUser extends Mix(
+    ApplicationRecord,
+    hasSecurePassword({ validations: false })
+  ) {}
+  const user = new NoValidationsUser();
+  // @ts-ignore
+  user.passwordConfirmation = "nomatch";
+  expect(user.isValid()).toBe(true);
+});
+
+test("hasSecurePassword() with custom attribute", () => {
+  class CustomAttributeUser extends Mix(
+    ApplicationRecord,
+    hasSecurePassword({ attribute: "recovery" })
+  ) {}
+  const user = new CustomAttributeUser();
+  // @ts-ignore
+  user.recovery = "mUc3m00RsqyRe";
+  // @ts-ignore
+  user.recoveryConfirmation = "mUc3m00RsqyRe";
+  expect(user.isValid()).toBe(true);
 });

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -21,6 +21,9 @@ test("hasSecurePassword()", () => {
 
   User.findBy({ name: "david" })?.authenticate("notright"); //=> false
   User.findBy({ name: "david" })?.authenticate("mUc3m00RsqyRe"); //=> user
+
+  // @ts-expect-error
+  user.hoge;
 });
 
 test("hasSecurePassword() with validations: false", () => {
@@ -29,7 +32,6 @@ test("hasSecurePassword() with validations: false", () => {
     hasSecurePassword({ validations: false })
   ) {}
   const user = new NoValidationsUser();
-  // @ts-ignore
   user.passwordConfirmation = "nomatch";
   expect(user.isValid()).toBe(true);
 });
@@ -40,9 +42,6 @@ test("hasSecurePassword() with custom attribute", () => {
     hasSecurePassword({ attribute: "recovery" })
   ) {}
   const user = new CustomAttributeUser();
-  // @ts-ignore
-  user.recovery = "mUc3m00RsqyRe";
-  // @ts-ignore
-  user.recoveryConfirmation = "mUc3m00RsqyRe";
+  user.recovery = user.recoveryConfirmation = "mUc3m00RsqyRe";
   expect(user.isValid()).toBe(true);
 });

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -3,6 +3,9 @@ import { User } from "..";
 import { $user } from "../../factories/user";
 import { ApplicationRecord } from "../applicationRecord";
 
+const validPassword = "xBOHdowK5e2YjQ1s";
+const validRecovery = "l36pjDtp7TZtBqjm";
+
 test("hasSecurePassword()", () => {
   const user = $user.build({});
   user.password = "";
@@ -10,33 +13,30 @@ test("hasSecurePassword()", () => {
   expect(user.save()).toBe(false);
   expect(user.errors.fullMessages).toEqual(["Password can't be blank"]);
 
-  user.password = "xBOHdowK5e2YjQ1s";
+  user.password = validPassword;
   expect(user.save()).toBe(false);
   expect(user.errors.fullMessages).toEqual([
     "PasswordConfirmation does not match password",
   ]);
 
-  user.passwordConfirmation = "xBOHdowK5e2YjQ1s";
+  user.passwordConfirmation = validPassword;
   expect(user.save()).toBe(true);
   expect(user.errors.fullMessages).toEqual([]);
 
   expect(user.passwordDigest).not.toBeFalsy();
 
   expect(user.authenticate("invalid")).toBe(false);
-  expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
-  expect(user.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(user.authenticate(validPassword)).toBe(true);
+  expect(user.authenticatePassword(validPassword)).toBe(true);
 
   const u = User.find(user.id!);
   expect(u.authenticate("invalid")).toBe(false);
-  expect(u.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
-  expect(u.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
-
-  // @ts-expect-error
-  user.hoge;
+  expect(u.authenticate(validPassword)).toBe(true);
+  expect(u.authenticatePassword(validPassword)).toBe(true);
 });
 
 test("hasSecurePassword() on create", () => {
-  const password = "xBOHdowK5e2YjQ1s";
+  const password = validPassword;
   const user = $user.build({
     password: password,
     passwordConfirmation: password,
@@ -61,9 +61,9 @@ test("hasSecurePassword() with custom attribute", () => {
     hasSecurePassword({ attribute: "recovery" })
   ) {}
   const user = new CustomAttributeUser();
-  user.recovery = user.recoveryConfirmation = "xBOHdowK5e2YjQ1s";
+  user.recovery = user.recoveryConfirmation = validRecovery;
   expect(user.isValid()).toBe(true);
-  expect(user.authenticateRecovery("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(user.authenticateRecovery(validRecovery)).toBe(true);
 });
 
 test("hasSecurePassword() multiple", () => {
@@ -73,13 +73,13 @@ test("hasSecurePassword() multiple", () => {
     hasSecurePassword({ attribute: "recovery", validations: false })
   ) {}
   const user = new MultiplePasswordUser();
-  user.password = user.passwordConfirmation = "xBOHdowK5e2YjQ1s";
-  user.recovery = user.recoveryConfirmation = "l36pjDtp7TZtBqjm";
+  user.password = user.passwordConfirmation = validPassword;
+  user.recovery = user.recoveryConfirmation = validRecovery;
   expect(user.isValid()).toBe(true);
-  expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
-  expect(user.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
-  expect(user.authenticateRecovery("l36pjDtp7TZtBqjm")).toBe(true);
+  expect(user.authenticate(validPassword)).toBe(true);
+  expect(user.authenticatePassword(validPassword)).toBe(true);
+  expect(user.authenticateRecovery(validRecovery)).toBe(true);
 
-  expect(user.password).toBe("xBOHdowK5e2YjQ1s");
-  expect(user.recovery).toBe("l36pjDtp7TZtBqjm");
+  expect(user.password).toBe(validPassword);
+  expect(user.recovery).toBe(validRecovery);
 });

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -24,10 +24,12 @@ test("hasSecurePassword()", () => {
 
   expect(user.authenticate("invalid")).toBe(false);
   expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(user.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
 
   const u = User.find(user.id!);
   expect(u.authenticate("invalid")).toBe(false);
   expect(u.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(u.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
 
   // @ts-expect-error
   user.hoge;
@@ -61,4 +63,23 @@ test("hasSecurePassword() with custom attribute", () => {
   const user = new CustomAttributeUser();
   user.recovery = user.recoveryConfirmation = "xBOHdowK5e2YjQ1s";
   expect(user.isValid()).toBe(true);
+  expect(user.authenticateRecovery("xBOHdowK5e2YjQ1s")).toBe(true);
+});
+
+test("hasSecurePassword() multiple", () => {
+  class MultiplePasswordUser extends Mix(
+    ApplicationRecord,
+    hasSecurePassword(),
+    hasSecurePassword({ attribute: "recovery", validations: false })
+  ) {}
+  const user = new MultiplePasswordUser();
+  user.password = user.passwordConfirmation = "xBOHdowK5e2YjQ1s";
+  user.recovery = user.recoveryConfirmation = "l36pjDtp7TZtBqjm";
+  expect(user.isValid()).toBe(true);
+  expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(user.authenticatePassword("xBOHdowK5e2YjQ1s")).toBe(true);
+  expect(user.authenticateRecovery("l36pjDtp7TZtBqjm")).toBe(true);
+
+  expect(user.password).toBe("xBOHdowK5e2YjQ1s");
+  expect(user.recovery).toBe("l36pjDtp7TZtBqjm");
 });

--- a/tests/models/model/securePassword.test.ts
+++ b/tests/models/model/securePassword.test.ts
@@ -20,7 +20,7 @@ test("hasSecurePassword()", () => {
   expect(user.save()).toBe(true);
   expect(user.errors.fullMessages).toEqual([]);
 
-  expect(user.passwordDigest).not.toBeUndefined();
+  expect(user.passwordDigest).not.toBeFalsy();
 
   expect(user.authenticate("invalid")).toBe(false);
   expect(user.authenticate("xBOHdowK5e2YjQ1s")).toBe(true);
@@ -31,6 +31,16 @@ test("hasSecurePassword()", () => {
 
   // @ts-expect-error
   user.hoge;
+});
+
+test("hasSecurePassword() on create", () => {
+  const password = "xBOHdowK5e2YjQ1s";
+  const user = $user.build({
+    password: password,
+    passwordConfirmation: password,
+  });
+  expect(user.passwordDigest).not.toBeUndefined();
+  expect(user.save()).toBe(true);
 });
 
 test("hasSecurePassword() with validations: false", () => {

--- a/tests/models/relation/serialization.test-d.ts
+++ b/tests/models/relation/serialization.test-d.ts
@@ -7,6 +7,7 @@ test("Relation#toHashArray()", () => {
     name: string | undefined;
     age: number | undefined;
     email: string;
+    passwordDigest: string | undefined;
     createdAt: Date;
     updatedAt: Date;
   }>();

--- a/tests/models/serialization.test-d.ts
+++ b/tests/models/serialization.test-d.ts
@@ -8,6 +8,7 @@ test("toHash", () => {
     name: string | undefined;
     age: number | undefined;
     email: string;
+    passwordDigest: string | undefined;
     createdAt: Date;
     updatedAt: Date;
   }>();
@@ -18,7 +19,7 @@ test("toHash", () => {
   }>();
 
   expectTypeOf(
-    u.toHash({ except: ["createdAt", "updatedAt", "email"] })
+    u.toHash({ except: ["createdAt", "updatedAt", "email", "passwordDigest"] })
   ).toEqualTypeOf<{
     id: number;
     name: string | undefined;

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -1,3 +1,4 @@
+import { hasSecurePassword, Mix } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
 
-export class UserModel extends ApplicationRecord {}
+export class UserModel extends Mix(ApplicationRecord, hasSecurePassword()) {}

--- a/tests/prisma/migrations/20240709161015_add_password_digest_to_user/migration.sql
+++ b/tests/prisma/migrations/20240709161015_add_password_digest_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "passwordDigest" TEXT;

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -13,16 +13,17 @@ datasource db {
 }
 
 model User {
-  id        Int        @id @default(autoincrement()) @map("_id")
-  email     String     @unique
-  name      String?    @map("user_name")
-  age       Int?
-  posts     Post[]
-  setting   Setting?
-  teams     UserTeam[]
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  Profile   Profile?
+  id             Int        @id @default(autoincrement()) @map("_id")
+  email          String     @unique
+  passwordDigest String?
+  name           String?    @map("user_name")
+  age            Int?
+  posts          Post[]
+  setting        Setting?
+  teams          UserTeam[]
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+  Profile        Profile?
 }
 
 model Team {

--- a/tests/prisma_mysql/migrations/20240626065419_add_password_digest_to_user/migration.sql
+++ b/tests/prisma_mysql/migrations/20240626065419_add_password_digest_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `passwordDigest` VARCHAR(191) NULL;

--- a/tests/prisma_mysql/schema.prisma
+++ b/tests/prisma_mysql/schema.prisma
@@ -14,16 +14,17 @@ datasource db {
 }
 
 model User {
-  id        Int        @id @default(autoincrement()) @map("_id")
-  email     String     @unique
-  name      String?    @map("user_name")
-  age       Int?
-  posts     Post[]
-  setting   Setting?
-  teams     UserTeam[]
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  Profile   Profile?
+  id             Int        @id @default(autoincrement()) @map("_id")
+  email          String     @unique
+  passwordDigest String?
+  name           String?    @map("user_name")
+  age            Int?
+  posts          Post[]
+  setting        Setting?
+  teams          UserTeam[]
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+  Profile        Profile?
 }
 
 model Team {

--- a/tests/prisma_pg/migrations/20240709164329_add_password_digest_to_user/migration.sql
+++ b/tests/prisma_pg/migrations/20240709164329_add_password_digest_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "passwordDigest" TEXT;

--- a/tests/prisma_pg/schema.prisma
+++ b/tests/prisma_pg/schema.prisma
@@ -14,16 +14,17 @@ datasource db {
 }
 
 model User {
-  id        Int        @id @default(autoincrement()) @map("_id")
-  email     String     @unique
-  name      String?    @map("user_name")
-  age       Int?
-  posts     Post[]
-  setting   Setting?
-  teams     UserTeam[]
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  Profile   Profile?
+  id             Int        @id @default(autoincrement()) @map("_id")
+  email          String     @unique
+  passwordDigest String?
+  name           String?    @map("user_name")
+  age            Int?
+  posts          Post[]
+  setting        Setting?
+  teams          UserTeam[]
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+  Profile        Profile?
 }
 
 model Team {


### PR DESCRIPTION
We provide a mechanism for securely hashing and authenticating passwords using Bcrypt.

First, add a `passwordDigest` field to the model to store the hashed password.

```ts
// prisma/schema.prisma
model User {
  ...
  passwordDigest String // Stores the hash value of the password
}
```

Next, use `hasSecurePassword()` to add functionality to the model for hashing and authenticating passwords.

```ts
// ./models/user.ts
import { hasSecurePassword, Mix } from "accel-record";
import { ApplicationRecord } from "./applicationRecord.js";

export class UserModel extends Mix(ApplicationRecord, hasSecurePassword()) {}
```

With this, you can perform password validation and hashing using the `password` and `passwordConfirmation` fields, and authenticate passwords using the `authenticate()` method.

```ts
import { User } from "./models/index.js";

const user = User.build({});
user.password = "";
user.save(); // => false (password can't be blank)
user.password = "myPassword";
user.save(); // => false (password confirmation doesn't match)
user.passwordConfirmation = "myPassword";
user.save(); // => true

user.authenticate("invalid"); // => false
user.authenticate("myPassword"); // => true
```

You can customize the field name for storing the password by setting it to something other than `passwordDigest`, and you can manage multiple passwords in the model as well.

```ts
// ./models/user.ts
import { hasSecurePassword, Mix } from "accel-record";
import { ApplicationRecord } from "./applicationRecord.js";

export class UserModel extends Mix(
  ApplicationRecord,
  hasSecurePassword(), // Uses the passwordDigest field
  hasSecurePassword({ attribute: "recovery", validation: false }) // Uses the recoveryDigest field
) {}
```