### PR TITLE
Scopes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -65,7 +64,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -81,7 +79,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -97,7 +94,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -113,7 +109,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -129,7 +124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -145,7 +139,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -161,7 +154,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -177,7 +169,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -193,7 +184,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -209,7 +199,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -225,7 +214,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -241,7 +229,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -257,7 +244,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -273,7 +259,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -289,7 +274,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -305,7 +289,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -321,7 +304,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -337,7 +319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -353,7 +334,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -369,7 +349,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -385,7 +364,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -401,7 +379,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1116,7 +1093,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2792,6 +2768,7 @@
       "dependencies": {
         "@prisma/client": "^5.0.0",
         "@prisma/generator-helper": "^5.0.0",
+        "esbuild": ">=0.21.0",
         "prettier": "^3.0.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
@@ -267,9 +267,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
-      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
@@ -315,9 +315,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
@@ -363,9 +363,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1125,29 +1125,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.19.12",
-        "@esbuild/android-arm": "0.19.12",
-        "@esbuild/android-arm64": "0.19.12",
-        "@esbuild/android-x64": "0.19.12",
-        "@esbuild/darwin-arm64": "0.19.12",
-        "@esbuild/darwin-x64": "0.19.12",
-        "@esbuild/freebsd-arm64": "0.19.12",
-        "@esbuild/freebsd-x64": "0.19.12",
-        "@esbuild/linux-arm": "0.19.12",
-        "@esbuild/linux-arm64": "0.19.12",
-        "@esbuild/linux-ia32": "0.19.12",
-        "@esbuild/linux-loong64": "0.19.12",
-        "@esbuild/linux-mips64el": "0.19.12",
-        "@esbuild/linux-ppc64": "0.19.12",
-        "@esbuild/linux-riscv64": "0.19.12",
-        "@esbuild/linux-s390x": "0.19.12",
-        "@esbuild/linux-x64": "0.19.12",
-        "@esbuild/netbsd-x64": "0.19.12",
-        "@esbuild/openbsd-x64": "0.19.12",
-        "@esbuild/sunos-x64": "0.19.12",
-        "@esbuild/win32-arm64": "0.19.12",
-        "@esbuild/win32-ia32": "0.19.12",
-        "@esbuild/win32-x64": "0.19.12"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escalade": {
@@ -1291,9 +1291,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
-      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
       "dev": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -2480,13 +2480,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.1.tgz",
-      "integrity": "sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.16.2.tgz",
+      "integrity": "sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==",
       "dev": true,
       "dependencies": {
-        "esbuild": "~0.19.10",
-        "get-tsconfig": "^4.7.2"
+        "esbuild": "~0.21.5",
+        "get-tsconfig": "^4.7.5"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2625,412 +2625,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite/node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/vitest": {

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -1,4 +1,3 @@
-import "./support.js";
 import { Association } from "./associations/association.js";
 import { Collection } from "./associations/collectionProxy.js";
 import { HasManyAssociation } from "./associations/hasManyAssociation.js";
@@ -15,23 +14,25 @@ import { Serialization } from "./model/serialization.js";
 import { Validations } from "./model/validations.js";
 import { Persistence } from "./persistence.js";
 import { Query } from "./query.js";
+import "./support.js";
 import { Transaction } from "./transaction.js";
 import { Mix } from "./utils.js";
 
 export { Collection } from "./associations/collectionProxy.js";
+export { after, before } from "./callbacks.js";
 export {
   getConfig,
   initAccelRecord,
   stopRpcClient as stopWorker,
 } from "./database.js";
 export { Migration } from "./migration.js";
+export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";
+export { scope } from "./scope.js";
 export { DatabaseCleaner } from "./testUtils.js";
 export { Rollback } from "./transaction.js";
 export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
-export { before, after } from "./callbacks.js";
-export { hasSecurePassword } from "./model/securePassword.js";
 
 export { Mix };
 

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -14,7 +14,7 @@ export class Query {
    */
   static all<T extends typeof Model>(
     this: T
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return new Relation(this);
   }
 
@@ -27,8 +27,8 @@ export class Query {
   static findOrCreateBy<T extends typeof Model>(
     this: T,
     params: Parameters<typeof Model.create<T>>[0],
-    callback?: (obj: InstanceType<T>) => void
-  ): InstanceType<T> {
+    callback?: (obj: Meta<T>["Persisted"]) => void
+  ): Meta<T>["Persisted"] {
     const user = this.findBy(params);
     if (user) return user;
     const newUser = this.create(params);
@@ -62,7 +62,7 @@ export class Query {
   static includes<T extends typeof Model>(
     this: T,
     ...input: Meta<T>["AssociationKey"][]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().includes(...input);
   }
 
@@ -74,7 +74,7 @@ export class Query {
   static joins<T extends typeof Model>(
     this: T,
     ...input: Meta<T>["AssociationKey"][]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().joins(...input);
   }
 
@@ -88,7 +88,7 @@ export class Query {
     this: T,
     query: string,
     ...bindings: any[]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().joinsRaw(query, ...bindings);
   }
 
@@ -101,7 +101,7 @@ export class Query {
     this: T,
     ...attributes: F
     // @ts-ignore
-  ): Relation<{ [K in F[number]]: InstanceType<T>[K] }, Meta<T>> {
+  ): Relation<{ [K in F[number]]: Meta<T>["Persisted"][K] }, Meta<T>> {
     // @ts-ignore
     return this.all().select(...attributes);
   }
@@ -129,16 +129,18 @@ export class Query {
   static first<T extends typeof Model>(
     this: T,
     limit: number
-  ): InstanceType<T>[];
+  ): Meta<T>["Persisted"][];
   /**
    * Retrieves the first record of the model.
    * @returns The first record of the model.
    */
-  static first<T extends typeof Model>(this: T): InstanceType<T> | undefined;
+  static first<T extends typeof Model>(
+    this: T
+  ): Meta<T>["Persisted"] | undefined;
   static first<T extends typeof Model>(
     this: T,
     limit?: number
-  ): InstanceType<T> | InstanceType<T>[] | undefined {
+  ): Meta<T>["Persisted"] | Meta<T>["Persisted"][] | undefined {
     return limit ? this.all().first(limit) : this.all().first();
   }
 
@@ -149,16 +151,18 @@ export class Query {
   static last<T extends typeof Model>(
     this: T,
     limit: number
-  ): InstanceType<T>[];
+  ): Meta<T>["Persisted"][];
   /**
    * Retrieves the last record of the model.
    * @returns The last record of the model.
    */
-  static last<T extends typeof Model>(this: T): InstanceType<T> | undefined;
+  static last<T extends typeof Model>(
+    this: T
+  ): Meta<T>["Persisted"] | undefined;
   static last<T extends typeof Model>(
     this: T,
     limit?: number
-  ): InstanceType<T> | InstanceType<T>[] | undefined {
+  ): Meta<T>["Persisted"] | Meta<T>["Persisted"][] | undefined {
     return limit ? this.all().last(limit) : this.all().last();
   }
 
@@ -208,7 +212,7 @@ export class Query {
     this: T,
     attribute: keyof Meta<T>["Column"],
     direction?: "asc" | "desc"
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().order(attribute, direction);
   }
 
@@ -220,7 +224,7 @@ export class Query {
   static offset<T extends typeof Model>(
     this: T,
     offset: number
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().offset(offset);
   }
 
@@ -232,7 +236,7 @@ export class Query {
   static limit<T extends typeof Model>(
     this: T,
     limit: number
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().limit(limit);
   }
 
@@ -241,12 +245,12 @@ export class Query {
    * @description Filters the model instances based on the provided input.
    * @param {T} this - The model class.
    * @param {Meta<T>['WhereInput']} input - The input data for filtering the model instances.
-   * @returns {Relation<InstanceType<T>, Meta<T>>} - The relation containing the filtered model instances.
+   * @returns {Relation<Meta<T>['Persisted'], Meta<T>>} - The relation containing the filtered model instances.
    */
   static where<T extends typeof Model>(
     this: T,
     input: Meta<T>["WhereInput"]
-  ): Relation<InstanceType<T>, Meta<T>>;
+  ): Relation<Meta<T>["Persisted"], Meta<T>>;
 
   /**
    * @function where
@@ -254,19 +258,19 @@ export class Query {
    * @param {T} this - The model class.
    * @param {string} query - The query string.
    * @param {...any[]} bindings - The query bindings.
-   * @returns {Relation<InstanceType<T>, Meta<T>>} - The relation containing the filtered model instances.
+   * @returns {Relation<Meta<T>['Persisted'], Meta<T>>} - The relation containing the filtered model instances.
    */
   static where<T extends typeof Model>(
     this: T,
     query: string,
     ...bindings: any[]
-  ): Relation<InstanceType<T>, Meta<T>>;
+  ): Relation<Meta<T>["Persisted"], Meta<T>>;
 
   static where<T extends typeof Model>(
     this: T,
     queryOrInput: string | Meta<T>["WhereInput"],
     ...bindings: any[]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     if (typeof queryOrInput === "string") {
       return this.whereRaw(queryOrInput, ...bindings);
     } else {
@@ -282,7 +286,7 @@ export class Query {
   static whereNot<T extends typeof Model>(
     this: T,
     input: Meta<T>["WhereInput"]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().whereNot(input);
   }
 
@@ -296,7 +300,7 @@ export class Query {
     this: T,
     query: string,
     ...bindings: any[]
-  ): Relation<InstanceType<T>, Meta<T>> {
+  ): Relation<Meta<T>["Persisted"], Meta<T>> {
     return this.all().whereRaw(query, ...bindings);
   }
 
@@ -313,7 +317,7 @@ export class Query {
     if (!instance) {
       throw new Error("Record Not found");
     }
-    return instance as InstanceType<T>;
+    return instance as Meta<T>["Persisted"];
   }
 
   /**
@@ -324,7 +328,7 @@ export class Query {
   static findBy<T extends typeof Model>(
     this: T,
     input: Meta<T>["WhereInput"]
-  ): InstanceType<T> | undefined {
+  ): Meta<T>["Persisted"] | undefined {
     return this.all().where(input).first();
   }
 

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -310,14 +310,17 @@ export class Query {
    * @returns The found record.
    * @throws An error if the record is not found.
    */
-  static find<T extends typeof Model>(this: T, id: number) {
+  static find<T extends typeof Model>(
+    this: T,
+    id: number
+  ): Meta<T>["Persisted"] {
     const instance = this.all()
       .setOption("wheres", [{ [this.primaryKeys[0]]: id }])
       .first();
     if (!instance) {
       throw new Error("Record Not found");
     }
-    return instance as Meta<T>["Persisted"];
+    return instance;
   }
 
   /**
@@ -378,7 +381,8 @@ export class Query {
     this: T,
     options?: { batchSize?: number }
   ) {
-    return this.all().findEach(options);
+    // @ts-ignore
+    return this.all().findEach<InstanceType<T>, Meta<T>>(options);
   }
 
   /**
@@ -391,6 +395,7 @@ export class Query {
     this: T,
     options?: { batchSize?: number }
   ) {
-    return this.all().findInBatches(options);
+    // @ts-ignore
+    return this.all().findInBatches<InstanceType<T>, Meta<T>>(options);
   }
 }

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -7,6 +7,7 @@ import { RelationBase } from "./base.js";
 import { Batches } from "./batches.js";
 import { Calculations } from "./calculations.js";
 import { getDefaultOptions, Options } from "./options.js";
+import { Merge } from "./merge.js";
 import { Query } from "./query.js";
 import { Where } from "./where.js";
 
@@ -20,6 +21,7 @@ export class Relation<T, M extends ModelMeta> extends Mix(
   Association,
   Batches,
   Calculations,
+  Merge,
   Query,
   RelationBase,
   Where
@@ -37,7 +39,7 @@ export class Relation<T, M extends ModelMeta> extends Mix(
     for (const [f, _] of getStaticProperties(model)) {
       const method = model[f as keyof typeof model] as any;
       if (method?.isAccelRecordScope) {
-        (this as any)[f] = method;
+        (this as any)[f] = (...args: any[]) => this.merge(method(...args));
       }
     }
   }

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -1,12 +1,12 @@
 import { Collection, Model } from "../index.js";
 import { type ModelMeta } from "../meta.js";
 import { ToHashOptions, ToHashResult } from "../model/serialization.js";
-import { Mix } from "../utils.js";
+import { getStaticProperties, Mix } from "../utils.js";
 import { Association } from "./association.js";
 import { RelationBase } from "./base.js";
 import { Batches } from "./batches.js";
 import { Calculations } from "./calculations.js";
-import { Options, getDefaultOptions } from "./options.js";
+import { getDefaultOptions, Options } from "./options.js";
 import { Query } from "./query.js";
 import { Where } from "./where.js";
 
@@ -34,6 +34,12 @@ export class Relation<T, M extends ModelMeta> extends Mix(
     super();
     this.model = model;
     this.options = Object.assign(getDefaultOptions(), options) as Options;
+    for (const [f, _] of getStaticProperties(model)) {
+      const method = model[f as keyof typeof model] as any;
+      if (method?.isAccelRecordScope) {
+        (this as any)[f] = method;
+      }
+    }
   }
   /**
    * Converts the relation to an array of type T.

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -39,8 +39,7 @@ export class Relation<T, M extends ModelMeta> extends Mix(
     for (const [f, _] of getStaticProperties(model)) {
       const method = model[f as keyof typeof model] as any;
       if (method?.isAccelRecordScope) {
-        (this as any)[f] = (...args: any[]) =>
-          this.merge(method.apply(this, args));
+        (this as any)[f] = (...args: any[]) => method.apply(this, args);
       }
     }
   }

--- a/packages/accel-record-core/src/relation/index.ts
+++ b/packages/accel-record-core/src/relation/index.ts
@@ -39,7 +39,8 @@ export class Relation<T, M extends ModelMeta> extends Mix(
     for (const [f, _] of getStaticProperties(model)) {
       const method = model[f as keyof typeof model] as any;
       if (method?.isAccelRecordScope) {
-        (this as any)[f] = (...args: any[]) => this.merge(method(...args));
+        (this as any)[f] = (...args: any[]) =>
+          this.merge(method.apply(this, args));
       }
     }
   }

--- a/packages/accel-record-core/src/relation/merge.ts
+++ b/packages/accel-record-core/src/relation/merge.ts
@@ -1,0 +1,41 @@
+import { ModelMeta } from "../meta.js";
+import { Relation } from "./index.js";
+
+export class Merge {
+  merge<T, M extends ModelMeta>(
+    this: Relation<T, M>,
+    relation: Relation<T, M>
+  ): Relation<T, M> {
+    this.options = deepMerge(this.options, relation.options);
+    return this;
+  }
+}
+
+function isObject(item: any): item is Object {
+  return item && typeof item === "object" && !Array.isArray(item);
+}
+
+function mergeArrays<T>(arr1: T[], arr2: T[]): T[] {
+  return Array.from(new Set([...arr1, ...arr2]));
+}
+
+function deepMerge<T extends object>(target: T, source: T): T;
+function deepMerge(target: any, source: any) {
+  let output = Object.assign({}, target);
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach((key) => {
+      if (isObject(source[key])) {
+        if (!(key in target)) Object.assign(output, { [key]: source[key] });
+        else output[key] = deepMerge(target[key], source[key]);
+      } else if (Array.isArray(source[key])) {
+        output[key] =
+          target[key] && Array.isArray(target[key])
+            ? mergeArrays(target[key], source[key])
+            : source[key];
+      } else {
+        Object.assign(output, { [key]: source[key] });
+      }
+    });
+  }
+  return output;
+}

--- a/packages/accel-record-core/src/scope.ts
+++ b/packages/accel-record-core/src/scope.ts
@@ -1,5 +1,16 @@
 import { Relation } from "./relation/index.js";
 
+/**
+ * Decorator function that marks a method as an AccelRecord scope.
+ *
+ * @example
+ * export class ArticleModel extends ApplicationRecord {
+ *  @ scope
+ *  static published() {
+ *    return this.where({ published: true });
+ *  }
+ *}
+ */
 export function scope(
   method: (...args: any[]) => Relation<any, any>,
   context: any

--- a/packages/accel-record-core/src/scope.ts
+++ b/packages/accel-record-core/src/scope.ts
@@ -1,0 +1,9 @@
+import { Relation } from "./relation/index.js";
+
+export function scope(
+  method: (...args: any[]) => Relation<any, any>,
+  context: any
+) {
+  (method as any).isAccelRecordScope = true;
+  return method;
+}

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -117,7 +117,7 @@ const getInstanceMethods = <T>(arg: new (...args: any[]) => T) => {
   return properties;
 };
 
-const getStaticProperties = <T extends Function>(cls: T) => {
+export const getStaticProperties = <T extends Function>(cls: T) => {
   const properties = new Map<string, any>();
   let currentCls = cls;
 

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -29,6 +29,7 @@ MySQL, PostgreSQL, SQLiteでの利用が可能です。
 - [関連付け](#関連付け)
 - [クエリインターフェース](#クエリインターフェース)
 - [テスト](#テスト)
+- [スコープ](#スコープ)
 - [バリデーション](#バリデーション)
 - [コールバック](#コールバック)
 - [Serialization](#serialization)
@@ -744,6 +745,41 @@ const rows = User.queryBuilder.select("name").groupBy("name").execute();
 console.log(rows); // => [{ name: "John" }, { name: "Alice" }]
 ```
 
+## スコープ
+
+再利用可能なクエリの内容をスコープとして定義できます。
+
+スコープを定義するには、モデルにstaticなクラスメソッドを用意し、 `@scope` デコレータを付けます。
+その後 `prisma generate` を実行することで、スコープがクエリインターフェースに反映されます。
+
+```ts
+// src/models/user.ts
+
+import { scope } from "accel-record";
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class UserModel extends ApplicationRecord {
+  @scope
+  static johns() {
+    return this.where({ name: "John" });
+  }
+
+  @scope
+  static adults() {
+    return this.where({ age: { ">=": 20 } });
+  }
+}
+```
+
+上のような定義で、以下のようにスコープを利用することができます。
+
+```ts
+import { User } from "./models/index.js";
+
+// name が John で、 age が 20以上 のユーザー数を取得
+User.johns().adults().count(); // => 1
+```
+
 ## テスト
 
 ### Vitestを利用したテスト
@@ -1253,7 +1289,6 @@ user.update({ age: undefined });
 
 ## 今後予定されている機能追加
 
-- [accel-record-core] スコープ
 - [accel-record-core] 複合IDの対応
 - [accel-record-core] クエリインターフェースの拡充
 

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -28,6 +28,7 @@ It can be used with MySQL, PostgreSQL, and SQLite.
 - [Associations](#associations)
 - [Query Interface](#query-interface)
 - [Testing](#testing)
+- [Scopes](#scopes)
 - [Validation](#validation)
 - [Callbacks](#callbacks)
 - [Serialization](#serialization)
@@ -743,6 +744,41 @@ const rows = User.queryBuilder.select("name").groupBy("name").execute();
 console.log(rows); // => [{ name: "John" }, { name: "Alice" }]
 ```
 
+## Scopes
+
+You can define the content of reusable queries as scopes.
+
+To define a scope, create a static class method on the model and decorate it with `@scope`.
+After that, run `prisma generate` to reflect the scopes in the query interface.
+
+```ts
+// src/models/user.ts
+
+import { scope } from "accel-record";
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class UserModel extends ApplicationRecord {
+  @scope
+  static johns() {
+    return this.where({ name: "John" });
+  }
+
+  @scope
+  static adults() {
+    return this.where({ age: { ">=": 20 } });
+  }
+}
+```
+
+With the above definition, you can use the scopes as follows:
+
+```ts
+import { User } from "./models/index.js";
+
+// Get the count of users with name "John" and age greater than or equal to 20
+User.johns().adults().count(); // => 1
+```
+
 ## Testing
 
 ### Testing with Vitest
@@ -1252,7 +1288,6 @@ user.update({ age: undefined });
 
 ## Future Planned Features
 
-- [accel-record-core] Scopes
 - [accel-record-core] Support for Composite IDs
 - [accel-record-core] Expansion of Query Interface
 

--- a/packages/prisma-generator-accel-record/package.json
+++ b/packages/prisma-generator-accel-record/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@prisma/client": "^5.0.0",
     "@prisma/generator-helper": "^5.0.0",
+    "esbuild": ">=0.21.0",
     "prettier": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/prisma-generator-accel-record/src/generator.ts
+++ b/packages/prisma-generator-accel-record/src/generator.ts
@@ -24,7 +24,7 @@ generatorHandler({
     const outputDir = options.generator.output?.value!;
     await writeFileSafely(
       path.join(outputDir, `_types.ts`),
-      generateIndex(options)
+      await generateIndex(options)
     );
     const indexFile = path.join(outputDir, `index.ts`);
     if (!fs.existsSync(indexFile)) {

--- a/packages/prisma-generator-accel-record/src/generators/index.ts
+++ b/packages/prisma-generator-accel-record/src/generators/index.ts
@@ -1,11 +1,11 @@
 import { DMMF, GeneratorOptions } from "@prisma/generator-helper";
 import { generateTypes } from "./type";
 
-export const generateIndex = (options: GeneratorOptions) => {
+export const generateIndex = async (options: GeneratorOptions) => {
   return [
     cautionComment,
     generateExportAllModels(options.dmmf.datamodel.models as DMMF.Model[]),
-    generateTypes(options),
+    await generateTypes(options),
   ].join("\n");
 };
 

--- a/packages/prisma-generator-accel-record/src/generators/relation.ts
+++ b/packages/prisma-generator-accel-record/src/generators/relation.ts
@@ -1,5 +1,6 @@
 import { GeneratorOptions } from "@prisma/generator-helper";
 import { buildSync } from "esbuild";
+import fs from "fs";
 import path from "path";
 import { ModelWrapper } from "./wrapper";
 
@@ -7,6 +8,7 @@ const loadModels = async (options: GeneratorOptions) => {
   const outputDir = options.generator.output?.value!;
   const filePath = path.join(outputDir, "index.ts");
   const outfile = path.join(__dirname, "../.models.mjs");
+  if (!fs.existsSync(filePath)) return undefined;
   try {
     buildSync({
       entryPoints: [filePath],

--- a/packages/prisma-generator-accel-record/src/generators/relation.ts
+++ b/packages/prisma-generator-accel-record/src/generators/relation.ts
@@ -1,0 +1,79 @@
+import { GeneratorOptions } from "@prisma/generator-helper";
+import path from "path";
+import { ModelWrapper } from "./wrapper";
+
+const loadModels = async (options: GeneratorOptions) => {
+  const outputDir = options.generator.output?.value!;
+  const filePath = path.join(outputDir, "index.ts");
+  const outfile = path.join(__dirname, "../.models.mjs");
+  try {
+    const { buildSync } = await import("esbuild");
+    buildSync({
+      entryPoints: [filePath],
+      outfile: outfile,
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      sourcemap: false,
+      allowOverwrite: true,
+      packages: "external",
+      target: "node18",
+    });
+    return await eval(`import('${outfile}')`);
+  } catch {
+    console.log(
+      [
+        `[prisma-generator-accel-record] Warning: Failed to load models from '${filePath}'.`,
+        "Some features (such as scope) require esbuild 0.21.0 or higher.",
+      ].join(" ")
+    );
+    return undefined;
+  }
+};
+
+const getScopeMethods = <T extends Function>(cls: T) => {
+  const properties: string[] = [];
+  let currentCls = cls;
+
+  while (currentCls) {
+    Object.getOwnPropertyNames(currentCls).forEach((prop) => {
+      const desc = Object.getOwnPropertyDescriptor(currentCls, prop);
+      if (!desc || typeof desc.get === "function") return;
+      if ((currentCls as any)[prop]?.isAccelRecordScope) {
+        properties.push(prop);
+      }
+    });
+
+    currentCls = Object.getPrototypeOf(currentCls);
+    if (currentCls === Function.prototype) {
+      break;
+    }
+  }
+
+  return properties;
+};
+
+export const relationMethods = async (options: GeneratorOptions) => {
+  const m = await loadModels(options);
+  if (m == undefined) return "";
+  const methods = {} as Record<string, ModelWrapper[]>;
+  for (const _model of options.dmmf.datamodel.models) {
+    const model = new ModelWrapper(_model, options.dmmf.datamodel);
+    const definedModel = m[model.persistedModel];
+    if (!definedModel) continue;
+    for (const method of getScopeMethods(definedModel)) {
+      (methods[method] ||= []).push(model);
+    }
+  }
+  return (
+    Object.entries(methods)
+      .map(([name, models]) => {
+        const ts = models.map(
+          (m) =>
+            `T extends ${m.persistedModel} ? typeof ${m.baseModel}['${name}'] : `
+        );
+        return `\n    ${name}: (${ts.join("")}never);`;
+      })
+      .join("") + "\n  "
+  );
+};

--- a/packages/prisma-generator-accel-record/src/generators/relation.ts
+++ b/packages/prisma-generator-accel-record/src/generators/relation.ts
@@ -1,4 +1,5 @@
 import { GeneratorOptions } from "@prisma/generator-helper";
+import { buildSync } from "esbuild";
 import path from "path";
 import { ModelWrapper } from "./wrapper";
 
@@ -7,7 +8,6 @@ const loadModels = async (options: GeneratorOptions) => {
   const filePath = path.join(outputDir, "index.ts");
   const outfile = path.join(__dirname, "../.models.mjs");
   try {
-    const { buildSync } = await import("esbuild");
     buildSync({
       entryPoints: [filePath],
       outfile: outfile,
@@ -23,8 +23,8 @@ const loadModels = async (options: GeneratorOptions) => {
   } catch {
     console.log(
       [
-        `[prisma-generator-accel-record] Warning: Failed to load models from '${filePath}'.`,
-        "Some features (such as scope) require esbuild 0.21.0 or higher.",
+        `[prisma-generator-accel-record] Warning: Failed to load models from '${filePath}' with esbuild.`,
+        "Some features (such as scope) may not work correctly.",
       ].join(" ")
     );
     return undefined;

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -1,5 +1,6 @@
-import { DMMF, GeneratorOptions } from "@prisma/generator-helper";
-import { toCamelCase } from "./index.js";
+import { GeneratorOptions } from "@prisma/generator-helper";
+import { relationMethods } from "./relation.js";
+import { ModelWrapper } from "./wrapper.js";
 
 const getFilterType = (type: string) => {
   switch (type) {
@@ -13,100 +14,7 @@ const getFilterType = (type: string) => {
   }
 };
 
-class FieldWrapper {
-  name: DMMF.Field["name"];
-  relationFromFields: DMMF.Field["relationFromFields"];
-  hasDefaultValue: DMMF.Field["hasDefaultValue"];
-  isRequired: DMMF.Field["isRequired"];
-  isList: DMMF.Field["isList"];
-  isUpdatedAt: DMMF.Field["isUpdatedAt"];
-  type: DMMF.Field["type"];
-  relationName: DMMF.Field["relationName"];
-
-  constructor(
-    private field: DMMF.Field,
-    private datamodel: DMMF.Datamodel
-  ) {
-    this.name = field.name;
-    this.relationFromFields = field.relationFromFields;
-    this.hasDefaultValue = field.hasDefaultValue;
-    this.isRequired = field.isRequired;
-    this.isList = field.isList;
-    this.isUpdatedAt = field.isUpdatedAt;
-    this.type = field.type;
-    this.relationName = field.relationName;
-  }
-
-  get hasScalarDefault() {
-    if (
-      typeof this.field.default === "object" &&
-      "name" in this.field.default
-    ) {
-      return ["uuid", "cuid"].includes(this.field.default.name);
-    }
-    return (
-      this.field.default != undefined && typeof this.field.default !== "object"
-    );
-  }
-
-  get model() {
-    const model = this.datamodel.models.find((m) => m.name == this.field.type);
-    if (model) return new ModelWrapper(model, this.datamodel);
-    return undefined;
-  }
-
-  get typeName() {
-    switch (this.field.type) {
-      case "BigInt":
-      case "Decimal":
-      case "Float":
-      case "Int":
-        return "number";
-      case "Bytes":
-      case "String":
-        return "string";
-      case "Boolean":
-        return "boolean";
-      case "DateTime":
-        return "Date";
-      case "Json":
-        return "any";
-      default:
-        return this.model?.baseModel ?? this.field.type;
-    }
-  }
-}
-
-class ModelWrapper {
-  constructor(
-    private model: DMMF.Model,
-    private datamodel: DMMF.Datamodel
-  ) {}
-
-  get baseModel() {
-    return `${this.model.name}Model`;
-  }
-  get newModel() {
-    return `New${this.model.name}`;
-  }
-  get persistedModel() {
-    return `${this.model.name}`;
-  }
-  get collection() {
-    return `${this.model.name}Collection`;
-  }
-  get meta() {
-    return `${this.model.name}Meta`;
-  }
-  get fileName() {
-    return toCamelCase(this.model.name);
-  }
-  get fields() {
-    return this.model.fields.map((f) => new FieldWrapper(f, this.datamodel));
-  }
-}
-
-export const generateTypes = (options: GeneratorOptions) => {
+export const generateTypes = async (options: GeneratorOptions) => {
   let data = `import {
   registerModel,
   type Collection,
@@ -116,6 +24,8 @@ export const generateTypes = (options: GeneratorOptions) => {
 
 declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;
+
+  interface Relation<T, M> {${await relationMethods(options)}}
 }
 
 `;

--- a/packages/prisma-generator-accel-record/src/generators/wrapper.ts
+++ b/packages/prisma-generator-accel-record/src/generators/wrapper.ts
@@ -1,0 +1,95 @@
+import { DMMF } from "@prisma/generator-helper";
+import { toCamelCase } from ".";
+
+export class FieldWrapper {
+  name: DMMF.Field["name"];
+  relationFromFields: DMMF.Field["relationFromFields"];
+  hasDefaultValue: DMMF.Field["hasDefaultValue"];
+  isRequired: DMMF.Field["isRequired"];
+  isList: DMMF.Field["isList"];
+  isUpdatedAt: DMMF.Field["isUpdatedAt"];
+  type: DMMF.Field["type"];
+  relationName: DMMF.Field["relationName"];
+
+  constructor(
+    private field: DMMF.Field,
+    private datamodel: DMMF.Datamodel
+  ) {
+    this.name = field.name;
+    this.relationFromFields = field.relationFromFields;
+    this.hasDefaultValue = field.hasDefaultValue;
+    this.isRequired = field.isRequired;
+    this.isList = field.isList;
+    this.isUpdatedAt = field.isUpdatedAt;
+    this.type = field.type;
+    this.relationName = field.relationName;
+  }
+
+  get hasScalarDefault() {
+    if (
+      typeof this.field.default === "object" &&
+      "name" in this.field.default
+    ) {
+      return ["uuid", "cuid"].includes(this.field.default.name);
+    }
+    return (
+      this.field.default != undefined && typeof this.field.default !== "object"
+    );
+  }
+
+  get model() {
+    const model = this.datamodel.models.find((m) => m.name == this.field.type);
+    if (model) return new ModelWrapper(model, this.datamodel);
+    return undefined;
+  }
+
+  get typeName() {
+    switch (this.field.type) {
+      case "BigInt":
+      case "Decimal":
+      case "Float":
+      case "Int":
+        return "number";
+      case "Bytes":
+      case "String":
+        return "string";
+      case "Boolean":
+        return "boolean";
+      case "DateTime":
+        return "Date";
+      case "Json":
+        return "any";
+      default:
+        return this.model?.baseModel ?? this.field.type;
+    }
+  }
+}
+
+export class ModelWrapper {
+  constructor(
+    private model: DMMF.Model,
+    private datamodel: DMMF.Datamodel
+  ) {}
+
+  get baseModel() {
+    return `${this.model.name}Model`;
+  }
+  get newModel() {
+    return `New${this.model.name}`;
+  }
+  get persistedModel() {
+    return `${this.model.name}`;
+  }
+  get collection() {
+    return `${this.model.name}Collection`;
+  }
+  get meta() {
+    return `${this.model.name}Meta`;
+  }
+  get fileName() {
+    return toCamelCase(this.model.name);
+  }
+  get fields() {
+    return this.model.fields.map((f) => new FieldWrapper(f, this.datamodel));
+  }
+}

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -24,8 +24,9 @@ declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;
 
   interface Relation<T, M> {
-    john: (M extends UserMeta ? typeof UserModel['john'] : never)
-    adults: (M extends UserMeta ? typeof UserModel['adults'] : never)
+    john: (T extends User ? typeof UserModel['john'] : never);
+    adults: (T extends User ? typeof UserModel['adults'] : never);
+    teenagers: (T extends User ? typeof UserModel['teenagers'] : never);
   }
 }
 

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -26,7 +26,6 @@ declare module "accel-record" {
   interface Relation<T, M> {
     john: (T extends User ? typeof UserModel['john'] : never);
     adults: (T extends User ? typeof UserModel['adults'] : never);
-    teenagers: (T extends User ? typeof UserModel['teenagers'] : never);
   }
 }
 

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -22,6 +22,11 @@ import {
 
 declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;
+
+  interface Relation<T, M> {
+    john: (M extends UserMeta ? typeof UserModel['john'] : never)
+    adults: (M extends UserMeta ? typeof UserModel['adults'] : never)
+  }
 }
 
 type Meta<T> = T extends typeof UserModel | UserModel ? UserMeta :

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -24,7 +24,7 @@ declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;
 
   interface Relation<T, M> {
-    john: (T extends User ? typeof UserModel['john'] : never);
+    john: (T extends User ? typeof UserModel['john'] : T extends Post ? typeof PostModel['john'] : never);
     adults: (T extends User ? typeof UserModel['adults'] : never);
   }
 }

--- a/tests/models/associations/collectionProxy.test-d.ts
+++ b/tests/models/associations/collectionProxy.test-d.ts
@@ -5,7 +5,7 @@ import { PostModel } from "../post";
 describe("setter / getter", () => {
   test("NewUser#posts", () => {
     const u = $user.build();
-    expectTypeOf(u.posts.first()).toMatchTypeOf<PostModel | undefined>();
+    expectTypeOf(u.posts.toArray()[0]).toMatchTypeOf<PostModel | undefined>();
     assertType((u.posts = [Post.build({})]));
     assertType(u.posts.push([Post.build({})]));
   });

--- a/tests/models/model/scope.test-d.ts
+++ b/tests/models/model/scope.test-d.ts
@@ -18,6 +18,8 @@ test("scope", () => {
     .adults()
     .count();
 
+  User.first()!.posts.john();
+
   class TestModel extends Model {
     @scope
     static test() {

--- a/tests/models/model/scope.test-d.ts
+++ b/tests/models/model/scope.test-d.ts
@@ -1,0 +1,19 @@
+import { User } from "..";
+
+test("scope", () => {
+  User.john();
+  User.all().john().adults().count();
+  User.adults().john().count();
+  User.all()
+    .includes()
+    .joins()
+    .joinsRaw("")
+    .order("name")
+    .offset(0)
+    .limit(0)
+    .where({})
+    .whereNot({})
+    .whereRaw("")
+    .adults()
+    .count();
+});

--- a/tests/models/model/scope.test-d.ts
+++ b/tests/models/model/scope.test-d.ts
@@ -1,3 +1,4 @@
+import { Model, scope } from "accel-record";
 import { User } from "..";
 
 test("scope", () => {
@@ -16,4 +17,16 @@ test("scope", () => {
     .whereRaw("")
     .adults()
     .count();
+
+  class TestModel extends Model {
+    @scope
+    static test() {
+      return this.all();
+    }
+    // @ts-expect-error
+    @scope
+    static teenagers() {
+      this.count();
+    }
+  }
 });

--- a/tests/models/model/scope.test.ts
+++ b/tests/models/model/scope.test.ts
@@ -2,8 +2,8 @@ import { User } from "..";
 import { $user } from "../../factories/user";
 
 test("scope", () => {
-  $user.create({ name: "john", age: 19 });
-  $user.create({ name: "john", age: 20 });
+  $user.create({ name: "John", age: 19 });
+  $user.create({ name: "John", age: 20 });
 
   expect(User.john().count()).toBe(2);
   expect(User.john().adults().count()).toBe(1);

--- a/tests/models/model/scope.test.ts
+++ b/tests/models/model/scope.test.ts
@@ -1,0 +1,10 @@
+import { User } from "..";
+import { $user } from "../../factories/user";
+
+test("scope", () => {
+  $user.create({ name: "john", age: 19 });
+  $user.create({ name: "john", age: 20 });
+
+  expect(User.john().count()).toBe(2);
+  // expect(User.john().adulst().count()).toBe(1);
+});

--- a/tests/models/model/scope.test.ts
+++ b/tests/models/model/scope.test.ts
@@ -1,4 +1,5 @@
 import { User } from "..";
+import { $post } from "../../factories/post";
 import { $user } from "../../factories/user";
 
 test("scope", () => {
@@ -8,4 +9,13 @@ test("scope", () => {
   expect(User.john().count()).toBe(2);
   expect(User.john().adults().count()).toBe(1);
   expect(User.adults().john().count()).toBe(1);
+});
+
+test("scope from Collection", () => {
+  const users = $user.createList(2);
+  $post.create({ title: "John", author: users[0] });
+  $post.create({ title: "Smith", author: users[0] });
+  $post.create({ title: "John", author: users[1] });
+
+  expect(users[0].posts.john().count()).toBe(1);
 });

--- a/tests/models/model/scope.test.ts
+++ b/tests/models/model/scope.test.ts
@@ -6,5 +6,6 @@ test("scope", () => {
   $user.create({ name: "john", age: 20 });
 
   expect(User.john().count()).toBe(2);
-  // expect(User.john().adulst().count()).toBe(1);
+  expect(User.john().adults().count()).toBe(1);
+  expect(User.adults().john().count()).toBe(1);
 });

--- a/tests/models/post.ts
+++ b/tests/models/post.ts
@@ -1,6 +1,11 @@
+import { scope } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 export class PostModel extends ApplicationRecord {
+  @scope
+  static john() {
+    return this.where({ title: "John" });
+  }
   override validateAttributes() {
     this.validates("title", { presence: true });
   }

--- a/tests/models/relation/merge.test.ts
+++ b/tests/models/relation/merge.test.ts
@@ -1,0 +1,14 @@
+import { User } from "..";
+import { $user } from "../../factories/user";
+
+test("merge()", () => {
+  $user.create({ name: "foo", age: 20 });
+  $user.create({ name: "foo", age: 30 });
+  $user.create({ name: "bar", age: 20 });
+  const r1 = User.where({ name: "foo" });
+  const r2 = User.where({ age: 20 });
+
+  expect(r1.count()).toBe(2);
+  expect(r2.count()).toBe(2);
+  expect(r1.merge(r2).count()).toBe(1);
+});

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -1,11 +1,13 @@
+import { scope } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
-import { User } from "./index.js";
 
 export class UserModel extends ApplicationRecord {
-  static john(this: typeof User) {
+  @scope
+  static john() {
     return this.where({ name: "John" });
   }
-  static adults(this: typeof User) {
+  @scope
+  static adults() {
     return this.where({ age: { ">=": 20 } });
   }
 }

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -1,3 +1,11 @@
 import { ApplicationRecord } from "./applicationRecord.js";
+import { User } from "./index.js";
 
-export class UserModel extends ApplicationRecord {}
+export class UserModel extends ApplicationRecord {
+  static john(this: typeof User) {
+    return this.where({ name: "John" });
+  }
+  static adults(this: typeof User) {
+    return this.where({ age: { ">=": 20 } });
+  }
+}

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -1,19 +1,18 @@
 import { scope } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
-import { User } from "./index.js";
 
 export class UserModel extends ApplicationRecord {
   @scope
   static john() {
-    return User.where({ name: "John" });
+    return this.where({ name: "John" });
   }
   @scope
   static adults() {
-    return User.where({ age: { ">=": 20 } });
+    return this.where({ age: { ">=": 20 } });
   }
   // @ts-expect-error
   @scope
   static teenagers() {
-    User.count();
+    this.count();
   }
 }

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -10,9 +10,4 @@ export class UserModel extends ApplicationRecord {
   static adults() {
     return this.where({ age: { ">=": 20 } });
   }
-  // @ts-expect-error
-  @scope
-  static teenagers() {
-    this.count();
-  }
 }

--- a/tests/models/user.ts
+++ b/tests/models/user.ts
@@ -1,13 +1,19 @@
 import { scope } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
+import { User } from "./index.js";
 
 export class UserModel extends ApplicationRecord {
   @scope
   static john() {
-    return this.where({ name: "John" });
+    return User.where({ name: "John" });
   }
   @scope
   static adults() {
-    return this.where({ age: { ">=": 20 } });
+    return User.where({ age: { ">=": 20 } });
+  }
+  // @ts-expect-error
+  @scope
+  static teenagers() {
+    User.count();
   }
 }


### PR DESCRIPTION
You can define the content of reusable queries as scopes.

To define a scope, create a static class method on the model and decorate it with `@scope`.
After that, run `prisma generate` to reflect the scopes in the query interface.

```ts
// src/models/user.ts

import { scope } from "accel-record";
import { ApplicationRecord } from "./applicationRecord.js";

export class UserModel extends ApplicationRecord {
  @scope
  static johns() {
    return this.where({ name: "John" });
  }

  @scope
  static adults() {
    return this.where({ age: { ">=": 20 } });
  }
}
```

With the above definition, you can use the scopes as follows:

```ts
import { User } from "./models/index.js";

// Get the count of users with name "John" and age greater than or equal to 20
User.johns().adults().count(); // => 1
```