### PR TITLE
Make passwordDigest optional when calling create()

### DIFF
--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -196,11 +196,13 @@ const createInputs = (model: ModelWrapper) => {
           field.type == "Json"
             ? `${model.baseModel}["${field.name}"]`
             : `${field.typeName}${field.isList ? "[]" : ""}`;
-        if (field.name.endsWith("Digest") && field.type == "String") {
+        const matchPassword = field.name.match(/^(.+)Digest$/);
+        if (matchPassword && field.type == "String") {
+          const password = matchPassword[1];
           return [
             `\n    ${field.name}?: string;`,
-            `\n    ${field.name.replace("Digest", "")}?: string;`,
-            `\n    ${field.name.replace("Digest", "Confirmation")}?: string;`,
+            `\n    ${password}?: string;`,
+            `\n    ${password}Confirmation?: string;`,
           ].join("");
         }
         return `\n    ${field.name}${optional ? "?" : ""}: ${valType};`;

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -198,7 +198,7 @@ const createInputs = (model: ModelWrapper) => {
             : `${field.typeName}${field.isList ? "[]" : ""}`;
         if (field.name.endsWith("Digest") && field.type == "String") {
           return [
-            `\n    ${field.name}${optional ? "?" : ""}: string;`,
+            `\n    ${field.name}?: string;`,
             `\n    ${field.name.replace("Digest", "")}?: string;`,
             `\n    ${field.name.replace("Digest", "Confirmation")}?: string;`,
           ].join("");

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -552,6 +552,7 @@ export class Account extends AccountModel {};
 export interface Account extends AccountModel {
   id: number;
   email: string;
+  passwordDigest: string;
 };
 type AccountCollection<T extends AccountModel> = Collection<T, AccountMeta> | Collection<Account, AccountMeta>;
 type AccountMeta = {
@@ -562,12 +563,12 @@ type AccountMeta = {
   Column: {
     id: number;
     email: string;
-    passwordDigest: string | undefined;
+    passwordDigest: string;
   };
   CreateInput: {
     id?: number;
     email: string;
-    passwordDigest?: string;
+    passwordDigest: string;
     password?: string;
     passwordConfirmation?: string;
   };

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -568,7 +568,7 @@ type AccountMeta = {
   CreateInput: {
     id?: number;
     email: string;
-    passwordDigest: string;
+    passwordDigest?: string;
     password?: string;
     passwordConfirmation?: string;
   };

--- a/tests/models/model/securePassword.test-d.ts
+++ b/tests/models/model/securePassword.test-d.ts
@@ -1,11 +1,14 @@
 import { hasSecurePassword, Mix } from "accel-record-core";
-import { $Account } from "../../factories/account";
+import { Account } from "..";
 import { ApplicationRecord } from "../applicationRecord";
 
 test("hasSecurePassword()", () => {
-  const account = $Account.create();
-  account.password = "";
-  account.passwordConfirmation = "";
+  // Ensure that passwordDigest is not required
+  const account = Account.create({
+    email: "",
+    password: "",
+    passwordConfirmation: "",
+  });
   expectTypeOf(account.authenticate("")).toBeBoolean();
   expectTypeOf(account.authenticatePassword("")).toBeBoolean();
 

--- a/tests/prisma_mysql/migrations/20240723192013_require_password_digest_of_account/migration.sql
+++ b/tests/prisma_mysql/migrations/20240723192013_require_password_digest_of_account/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `passwordDigest` on table `Account` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `Account` MODIFY `passwordDigest` VARCHAR(191) NOT NULL;

--- a/tests/prisma_mysql/schema.prisma
+++ b/tests/prisma_mysql/schema.prisma
@@ -112,7 +112,7 @@ model ValidateSample {
 }
 
 model Account {
-  id             Int     @id @default(autoincrement())
-  email          String  @unique
-  passwordDigest String?
+  id             Int    @id @default(autoincrement())
+  email          String @unique
+  passwordDigest String
 }


### PR DESCRIPTION
passwordDigest is not required when create
```ts
  const account = Account.create({
    email: "",
    password: "",
    passwordConfirmation: "",
  });
```