### PR TITLE
Throw a RecordNotFound error when the id passed to find() is not finite.

### DIFF
--- a/packages/accel-record-core/src/errors.ts
+++ b/packages/accel-record-core/src/errors.ts
@@ -1,0 +1,1 @@
+export class RecordNotFound extends Error {}

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -25,7 +25,6 @@ export {
   initAccelRecord,
   stopRpcClient as stopWorker,
 } from "./database.js";
-export { RecordNotFound } from "./errors.js";
 export { Migration } from "./migration.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -25,6 +25,7 @@ export {
   initAccelRecord,
   stopRpcClient as stopWorker,
 } from "./database.js";
+export { RecordNotFound } from "./errors.js";
 export { Migration } from "./migration.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -314,11 +314,13 @@ export class Query {
     this: T,
     id: number
   ): Meta<T>["Persisted"] {
-    const instance = this.all()
-      .setOption("wheres", [{ [this.primaryKeys[0]]: id }])
-      .first();
+    const instance = isFinite(id)
+      ? this.all()
+          .setOption("wheres", [{ [this.primaryKeys[0]]: id }])
+          .first()
+      : undefined;
     if (!instance) {
-      throw new RecordNotFound("Record Not found");
+      throw new RecordNotFound("Record Not Found");
     }
     return instance;
   }

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -1,4 +1,4 @@
-import type { Model } from "./index.js";
+import { RecordNotFound, type Model } from "./index.js";
 import type { Meta } from "./meta.js";
 import { Relation } from "./relation/index.js";
 
@@ -318,7 +318,7 @@ export class Query {
       .setOption("wheres", [{ [this.primaryKeys[0]]: id }])
       .first();
     if (!instance) {
-      throw new Error("Record Not found");
+      throw new RecordNotFound("Record Not found");
     }
     return instance;
   }

--- a/packages/accel-record-core/src/query.ts
+++ b/packages/accel-record-core/src/query.ts
@@ -1,4 +1,5 @@
-import { RecordNotFound, type Model } from "./index.js";
+import { RecordNotFound } from "./errors.js";
+import { type Model } from "./index.js";
 import type { Meta } from "./meta.js";
 import { Relation } from "./relation/index.js";
 

--- a/packages/accel-record/package.json
+++ b/packages/accel-record/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "vitest",

--- a/packages/accel-record/src/errors.ts
+++ b/packages/accel-record/src/errors.ts
@@ -1,0 +1,1 @@
+export * from "accel-record-core/dist/errors";

--- a/tests/models/query.test.ts
+++ b/tests/models/query.test.ts
@@ -1,3 +1,4 @@
+import { RecordNotFound } from "accel-record";
 import { $post } from "../factories/post";
 import { $user } from "../factories/user";
 import { User } from "./index";
@@ -135,9 +136,11 @@ describe("Query", () => {
   });
 
   test(".find()", () => {
-    expect(() => {
+    try {
       User.find(1);
-    }).toThrow("Record Not found");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RecordNotFound);
+    }
     const u = $user.create({ name: "hoge", email: "hoge@example.com" });
     const s = User.find(u.id!);
     expect(s).toBeInstanceOf(User);

--- a/tests/models/query.test.ts
+++ b/tests/models/query.test.ts
@@ -1,4 +1,4 @@
-import { RecordNotFound } from "accel-record";
+import { RecordNotFound } from "accel-record/errors";
 import { $post } from "../factories/post";
 import { $user } from "../factories/user";
 import { User } from "./index";

--- a/tests/models/query.test.ts
+++ b/tests/models/query.test.ts
@@ -141,12 +141,15 @@ describe("Query", () => {
     } catch (e) {
       expect(e).toBeInstanceOf(RecordNotFound);
     }
-    const u = $user.create({ name: "hoge", email: "hoge@example.com" });
+    const u = $user.create({ id: 1, name: "hoge", email: "hoge@example.com" });
     const s = User.find(u.id!);
     expect(s).toBeInstanceOf(User);
     expect(s.id).toBe(u.id!);
     expect(s.name).toBe("hoge");
     expect(s.email).toBe("hoge@example.com");
+
+    expect(() => User.find(NaN)).toThrowError("Record Not Found");
+    expect(User.find("1" as any)).toBeInstanceOf(User);
   });
 
   test(".findBy()", () => {


### PR DESCRIPTION
```ts
User.find(1) // => User
User.find(NaN) // throw RecordNotFound
User.find("1" as any) // => User
```