### PR TITLE
Translation of Enums

### DIFF
--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -1,3 +1,4 @@
+import { Model } from "../index.js";
 import { i18n } from "../model/naming.js";
 
 export class Attribute {
@@ -39,3 +40,16 @@ export class Value {
     return this.name;
   }
 }
+
+export const defineEnumTextAttribute = (
+  base: typeof Model,
+  persisted: any,
+  name: string
+) => {
+  Object.defineProperty(base.prototype, `${name}Text`, {
+    get() {
+      return persisted[name].values.find((v: Value) => v.value == this[name])
+        ?.text;
+    },
+  });
+};

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -1,16 +1,18 @@
+import { i18n } from "../model/naming.js";
+
 export class Attribute {
   values: Value[];
 
   constructor(
-    protected klass: any,
-    protected name: string,
+    public klass: any,
+    public name: string,
     protected enums: object
   ) {
     this.values = Object.keys(this.enums).map((key) => new Value(this, key));
   }
 
   options() {
-    return this.values.map((v) => [v.value, v.text]);
+    return this.values.map((v) => [v.text, v.value]);
   }
 }
 
@@ -25,6 +27,15 @@ export class Value {
   }
 
   get text() {
+    const keys = [
+      `enums.${this.attribute.klass.name}.${this.attribute.name}.${this.name}`,
+      `enums.defaults.${this.attribute.name}.${this.name}`,
+      `enums.${this.attribute.name}.${this.name}`,
+    ];
+    for (const key of keys) {
+      const text = i18n?.t(key, "");
+      if (text) return text;
+    }
     return this.name;
   }
 }

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -2,18 +2,22 @@ import { Model } from "../index.js";
 import { i18n } from "../model/naming.js";
 
 export class Attribute {
-  values: Value[];
+  protected _values: Value[];
 
   constructor(
     public klass: any,
     public name: string,
     protected enums: object
   ) {
-    this.values = Object.keys(this.enums).map((key) => new Value(this, key));
+    this._values = Object.keys(this.enums).map((key) => new Value(this, key));
+  }
+
+  values() {
+    return this._values;
   }
 
   options() {
-    return this.values.map((v) => [v.text, v.value]);
+    return this.values().map((v) => [v.text, v.value]);
   }
 }
 
@@ -48,7 +52,7 @@ export const defineEnumTextAttribute = (
 ) => {
   Object.defineProperty(base.prototype, `${name}Text`, {
     get() {
-      return (persisted[name] as Attribute).values.find(
+      return (persisted[name] as Attribute).values().find(
         (v) => v.value == this[name]
       )?.text;
     },

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -1,0 +1,30 @@
+export class Attribute {
+  values: Value[];
+
+  constructor(
+    protected klass: any,
+    protected name: string,
+    protected enums: object
+  ) {
+    this.values = Object.keys(this.enums).map((key) => new Value(this, key));
+  }
+
+  options() {
+    return this.values.map((v) => [v.value, v.text]);
+  }
+}
+
+export class Value {
+  value: string;
+
+  constructor(
+    protected attribute: Attribute,
+    protected name: string
+  ) {
+    this.value = name;
+  }
+
+  get text() {
+    return this.name;
+  }
+}

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -50,14 +50,14 @@ export class Value {
 
   /**
    * Retrieves the localized text for the current enum value.
-   * 
+   *
    * The text is retrieved using the following keys in order:
    * - `enums.${klass}.${attribute}.${name}`
    * - `enums.defaults.${attribute}.${name}`
    * - `enums.${attribute}.${name}`
-   * 
+   *
    * If no localized text is found, the name of the enum value is returned.
-   * 
+   *
    * @returns The localized text for the enum value, or the name if no text is found.
    */
   get text() {
@@ -81,9 +81,9 @@ export const defineEnumTextAttribute = (
 ) => {
   Object.defineProperty(base.prototype, `${name}Text`, {
     get() {
-      return (persisted[name] as Attribute).values().find(
-        (v) => v.value == this[name]
-      )?.text;
+      return (persisted[name] as Attribute)
+        .values()
+        .find((v) => v.value == this[name])?.text;
     },
   });
 };

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -1,6 +1,9 @@
 import { Model } from "../index.js";
 import { i18n } from "../model/naming.js";
 
+/**
+ * Represents an enum attribute.
+ */
 export class Attribute {
   protected _values: Value[];
 
@@ -12,15 +15,29 @@ export class Attribute {
     this._values = Object.keys(this.enums).map((key) => new Value(this, key));
   }
 
+  /**
+   * Returns the values of the enum.
+   *
+   * @returns An array containing the values of the enum.
+   */
   values() {
     return this._values;
   }
 
-  options() {
+  /**
+   * Retrieves an array of options.
+   * Each option is represented as an array with two elements: the localized text and value.
+   *
+   * @returns The array of options.
+   */
+  options(): [string, string][] {
     return this.values().map((v) => [v.text, v.value]);
   }
 }
 
+/**
+ * Represents a value in an enumeration.
+ */
 export class Value {
   value: string;
 
@@ -31,6 +48,18 @@ export class Value {
     this.value = name;
   }
 
+  /**
+   * Retrieves the localized text for the current enum value.
+   * 
+   * The text is retrieved using the following keys in order:
+   * - `enums.${klass}.${attribute}.${name}`
+   * - `enums.defaults.${attribute}.${name}`
+   * - `enums.${attribute}.${name}`
+   * 
+   * If no localized text is found, the name of the enum value is returned.
+   * 
+   * @returns The localized text for the enum value, or the name if no text is found.
+   */
   get text() {
     const keys = [
       `enums.${this.attribute.klass.name}.${this.attribute.name}.${this.name}`,

--- a/packages/accel-record-core/src/enums/index.ts
+++ b/packages/accel-record-core/src/enums/index.ts
@@ -48,8 +48,9 @@ export const defineEnumTextAttribute = (
 ) => {
   Object.defineProperty(base.prototype, `${name}Text`, {
     get() {
-      return persisted[name].values.find((v: Value) => v.value == this[name])
-        ?.text;
+      return (persisted[name] as Attribute).values.find(
+        (v) => v.value == this[name]
+      )?.text;
     },
   });
 };

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -27,6 +27,7 @@ export {
   initAccelRecord,
   stopRpcClient as stopWorker,
 } from "./database.js";
+export { Attribute, defineEnumTextAttribute } from "./enums/index.js";
 export { Migration } from "./migration.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";
@@ -35,7 +36,6 @@ export { DatabaseCleaner } from "./testUtils.js";
 export { Rollback } from "./transaction.js";
 export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
-export { Attribute } from "./enums/index.js";
 
 export { Mix };
 

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -35,6 +35,7 @@ export { DatabaseCleaner } from "./testUtils.js";
 export { Rollback } from "./transaction.js";
 export { Errors } from "./validation/errors.js";
 export { Validator } from "./validation/validator/index.js";
+export { Attribute } from "./enums/index.js";
 
 export { Mix };
 

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -27,7 +27,6 @@ export {
   initAccelRecord,
   stopRpcClient as stopWorker,
 } from "./database.js";
-export { Attribute, defineEnumTextAttribute } from "./enums/index.js";
 export { Migration } from "./migration.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -1180,17 +1180,9 @@ i18next
     resources: {
       ja: {
         translation: {
-          accelrecord: {
-            models: {
-              User: "ユーザー",
-            },
-            attributes: {
-              User: {
-                firstName: "名",
-                lastName: "姓",
-              },
-            },
-          },
+          "accelrecord.models.User": "ユーザー",
+          "accelrecord.attributes.User.firstName": "名",
+          "accelrecord.attributes.User.lastName": "姓",
         },
       },
     },
@@ -1245,22 +1237,10 @@ i18next
     resources: {
       ja: {
         translation: {
-          accelrecord: {
-            models: {
-              User: "ユーザー",
-            },
-            attributes: {
-              User: {
-                firstName: "名",
-                lastName: "姓",
-              },
-            },
-            errors: {
-              messages: {
-                blank: "を入力してください",
-              },
-            },
-          },
+          "accelrecord.models.User": "ユーザー",
+          "accelrecord.attributes.User.firstName": "名",
+          "accelrecord.attributes.User.lastName": "姓",
+          "accelrecord.errors.messages.blank": "を入力してください", // 追加
         },
       },
     },

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -1267,6 +1267,60 @@ i18next
 
 式展開が `count` になっているものは、エラーメッセージに `%{count}` を含むときにその部分がオプションで指定された値に置き換えられます。
 
+### Enumの翻訳
+
+Enumの各値に対しても翻訳を定義することができます。
+
+```ts
+// prisma/schema.prisma
+
+enum Role {
+  MEMBER
+  ADMIN
+}
+
+model User {
+  /* ... */
+  role Role @default(MEMBER)
+}
+```
+
+`User.role.options()`で、Enumの各値に対応する翻訳を取得することができます。
+各`User`が持つ`role`に対して、`roleText`というプロパティでEnumの値に対応する翻訳を取得することができます。
+
+```ts
+import i18next from "i18next";
+import { User } from "./models/index.js";
+
+i18next
+  .init({
+    lng: "ja",
+    resources: {
+      ja: {
+        translation: {
+          "enums.User.Role.MEMBER": "メンバー",
+          "enums.User.Role.ADMIN": "管理者",
+        },
+      },
+    },
+  })
+  .then(() => {
+    User.role.options(); // => [["メンバー", "MEMBER"], ["管理者", "ADMIN"]]
+
+    const user = User.build({});
+    user.role; // => "MEMBER"
+    user.roleText; // => "メンバー"
+  });
+```
+
+`user.role`の例では、以下のキーを順に探し、最初に見つかったキーが利用されます。
+
+```
+enums.User.Role.MEMBER
+enums.defaults.Role.MEMBER
+enums.Role.MEMBER
+```
+
 ## パスワード認証
 
 Bcryptを利用してセキュアにハッシュ化したパスワードを保持し、それを用いて認証するための仕組みを提供しています。

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -1266,6 +1266,60 @@ The message keys corresponding to each validation are as follows:
 
 For those with interpolation set to `count`, that part will be replaced with the value specified in the option when the error message contains `%{count}`.
 
+### Translation of Enums
+
+You can define translations for each value of an Enum.
+
+```ts
+// prisma/schema.prisma
+
+enum Role {
+  MEMBER
+  ADMIN
+}
+
+model User {
+  /* ... */
+  role Role @default(MEMBER)
+}
+```
+
+You can use `User.role.options()` to retrieve the translations corresponding to each value of the Enum.
+For each `User` with a `role`, you can retrieve the translation corresponding to the Enum value using the `roleText` property.
+
+```ts
+import i18next from "i18next";
+import { User } from "./models/index.js";
+
+i18next
+  .init({
+    lng: "ja",
+    resources: {
+      ja: {
+        translation: {
+          "enums.User.Role.MEMBER": "Member",
+          "enums.User.Role.ADMIN": "Admin",
+        },
+      },
+    },
+  })
+  .then(() => {
+    User.role.options(); // => [["Member", "MEMBER"], ["Admin", "ADMIN"]]
+
+    const user = User.build({});
+    user.role; // => "MEMBER"
+    user.roleText; // => "Member"
+  });
+```
+
+In the example of `user.role`, the following keys will be searched in order, and the first key found will be used:
+
+```
+enums.User.Role.MEMBER
+enums.defaults.Role.MEMBER
+enums.Role.MEMBER
+```
+
 ## Password Authentication
 
 We provide a mechanism for securely hashing and authenticating passwords using Bcrypt.

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -1179,17 +1179,9 @@ i18next
     resources: {
       en: {
         translation: {
-          accelrecord: {
-            models: {
-              User: "User",
-            },
-            attributes: {
-              User: {
-                firstName: "First Name",
-                lastName: "Last Name",
-              },
-            },
-          },
+          "accelrecord.models.User": "User",
+          "accelrecord.attributes.User.firstName": "First Name",
+          "accelrecord.attributes.User.lastName": "Last Name",
         },
       },
     },
@@ -1244,22 +1236,10 @@ i18next
     resources: {
       en: {
         translation: {
-          accelrecord: {
-            models: {
-              User: "User",
-            },
-            attributes: {
-              User: {
-                firstName: "First Name",
-                lastName: "Last Name",
-              },
-            },
-            errors: {
-              messages: {
-                blank: "can't be blank",
-              },
-            },
-          },
+          "accelrecord.models.User": "User",
+          "accelrecord.attributes.User.firstName": "First Name",
+          "accelrecord.attributes.User.lastName": "Last Name",
+          "accelrecord.errors.messages.blank": "can't be blank", // Add
         },
       },
     },

--- a/packages/accel-record/package.json
+++ b/packages/accel-record/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./enums": {
+      "types": "./dist/enums.d.ts",
+      "default": "./dist/enums.js"
+    },
     "./search": {
       "types": "./dist/search.d.ts",
       "default": "./dist/search.js"

--- a/packages/accel-record/src/enums.ts
+++ b/packages/accel-record/src/enums.ts
@@ -1,0 +1,1 @@
+export * from "accel-record-core/dist/enums/index.js";

--- a/packages/prisma-generator-accel-record/src/generators/model/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/model/type.ts
@@ -23,8 +23,7 @@ type ${model.meta} = {
   WhereInput: {${whereInputs(model)}};
 };
 registerModel(${model.persistedModel});
-${defineEnumTextAttributes(model)}
-`;
+${defineEnumTextAttributes(model)}`;
 
 const defineEnumTextTypes = (model: ModelWrapper) =>
   model.fields
@@ -40,9 +39,9 @@ const defineEnumTextAttributes = (model: ModelWrapper) =>
     .filter((f) => f.kind == "enum")
     .map(
       (f) =>
-        `defineEnumTextAttribute(${model.baseModel}, ${model.persistedModel}, "${f.name}");`
+        `defineEnumTextAttribute(${model.baseModel}, ${model.persistedModel}, "${f.name}");\n`
     )
-    .join("\n");
+    .join("");
 
 const associationColumns = (model: ModelWrapper) =>
   model.fields

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -10,6 +10,10 @@ export const generateTypes = async (options: GeneratorOptions) => {
   type Filter,
   type StringFilter,
 } from "accel-record";
+import {
+  Attribute,
+  defineEnumTextAttribute,
+} from "accel-record/enums";
 
 declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;

--- a/packages/prisma-generator-accel-record/src/generators/wrapper.ts
+++ b/packages/prisma-generator-accel-record/src/generators/wrapper.ts
@@ -2,6 +2,7 @@ import { DMMF } from "@prisma/generator-helper";
 import { toCamelCase } from ".";
 
 export class FieldWrapper {
+  kind: DMMF.Field["kind"];
   name: DMMF.Field["name"];
   relationFromFields: DMMF.Field["relationFromFields"];
   hasDefaultValue: DMMF.Field["hasDefaultValue"];
@@ -15,6 +16,7 @@ export class FieldWrapper {
     private field: DMMF.Field,
     private datamodel: DMMF.Datamodel
   ) {
+    this.kind = field.kind;
     this.name = field.name;
     this.relationFromFields = field.relationFromFields;
     this.hasDefaultValue = field.hasDefaultValue;

--- a/tests/contexts/i18n.ts
+++ b/tests/contexts/i18n.ts
@@ -21,6 +21,9 @@ export const withI18n = () => {
       "accelrecord.attributes.ValidateSample.size": "サイズ",
       "accelrecord.attributes.ValidateSample.key": "キー",
 
+      "enums.Role.MEMBER": "メンバー",
+      "enums.Role.ADMIN": "管理者",
+
       "errors.messages.blank": "を入力してください",
       "errors.messages.accepted": "をチェックしてください",
       "errors.messages.invalid": "は不正です",

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -76,7 +76,8 @@ declare module "./user" {
   }
 }
 export interface NewUser extends UserModel {};
-export class User extends UserModel {};
+export class User extends UserModel {
+};
 export interface User extends UserModel {
   id: number;
   email: string;
@@ -144,6 +145,7 @@ type UserMeta = {
 };
 registerModel(User);
 
+
 declare module "./team" {
   interface TeamModel {
     id: number | undefined;
@@ -153,7 +155,8 @@ declare module "./team" {
   }
 }
 export interface NewTeam extends TeamModel {};
-export class Team extends TeamModel {};
+export class Team extends TeamModel {
+};
 export interface Team extends TeamModel {
   id: number;
   name: string;
@@ -187,6 +190,7 @@ type TeamMeta = {
 };
 registerModel(Team);
 
+
 declare module "./userTeam" {
   interface UserTeamModel {
     user: User | undefined;
@@ -198,7 +202,8 @@ declare module "./userTeam" {
   }
 }
 export interface NewUserTeam extends UserTeamModel {};
-export class UserTeam extends UserTeamModel {};
+export class UserTeam extends UserTeamModel {
+};
 export interface UserTeam extends UserTeamModel {
   user: User;
   userId: number;
@@ -239,6 +244,7 @@ type UserTeamMeta = {
 };
 registerModel(UserTeam);
 
+
 declare module "./post" {
   interface PostModel {
     id: number | undefined;
@@ -252,7 +258,8 @@ declare module "./post" {
   }
 }
 export interface NewPost extends PostModel {};
-export class Post extends PostModel {};
+export class Post extends PostModel {
+};
 export interface Post extends PostModel {
   id: number;
   title: string;
@@ -298,6 +305,7 @@ type PostMeta = {
 };
 registerModel(Post);
 
+
 declare module "./postTag" {
   interface PostTagModel {
     id: number | undefined;
@@ -307,7 +315,8 @@ declare module "./postTag" {
   }
 }
 export interface NewPostTag extends PostTagModel {};
-export class PostTag extends PostTagModel {};
+export class PostTag extends PostTagModel {
+};
 export interface PostTag extends PostTagModel {
   id: number;
   name: string;
@@ -341,6 +350,7 @@ type PostTagMeta = {
 };
 registerModel(PostTag);
 
+
 declare module "./setting" {
   interface SettingModel {
     settingId: number | undefined;
@@ -352,7 +362,8 @@ declare module "./setting" {
   }
 }
 export interface NewSetting extends SettingModel {};
-export class Setting extends SettingModel {};
+export class Setting extends SettingModel {
+};
 export interface Setting extends SettingModel {
   settingId: number;
   user: User;
@@ -390,6 +401,7 @@ type SettingMeta = {
   };
 };
 registerModel(Setting);
+
 
 declare module "./profile" {
   interface ProfileModel {
@@ -456,7 +468,7 @@ type ProfileMeta = {
   };
 };
 registerModel(Profile);
-defineEnumTextAttribute(ProfileModel, Profile, 'role');
+defineEnumTextAttribute(ProfileModel, Profile, "role");
 
 declare module "./company" {
   interface CompanyModel {
@@ -467,7 +479,8 @@ declare module "./company" {
   }
 }
 export interface NewCompany extends CompanyModel {};
-export class Company extends CompanyModel {};
+export class Company extends CompanyModel {
+};
 export interface Company extends CompanyModel {
   id: number;
   name: string;
@@ -501,6 +514,7 @@ type CompanyMeta = {
 };
 registerModel(Company);
 
+
 declare module "./employee" {
   interface EmployeeModel {
     id: number | undefined;
@@ -510,7 +524,8 @@ declare module "./employee" {
   }
 }
 export interface NewEmployee extends EmployeeModel {};
-export class Employee extends EmployeeModel {};
+export class Employee extends EmployeeModel {
+};
 export interface Employee extends EmployeeModel {
   id: number;
   name: string;
@@ -545,6 +560,7 @@ type EmployeeMeta = {
 };
 registerModel(Employee);
 
+
 declare module "./validateSample" {
   interface ValidateSampleModel {
     id: number | undefined;
@@ -556,7 +572,8 @@ declare module "./validateSample" {
   }
 }
 export interface NewValidateSample extends ValidateSampleModel {};
-export class ValidateSample extends ValidateSampleModel {};
+export class ValidateSample extends ValidateSampleModel {
+};
 export interface ValidateSample extends ValidateSampleModel {
   id: number;
   accepted: boolean;
@@ -600,6 +617,7 @@ type ValidateSampleMeta = {
 };
 registerModel(ValidateSample);
 
+
 declare module "./account" {
   interface AccountModel {
     id: number | undefined;
@@ -608,7 +626,8 @@ declare module "./account" {
   }
 }
 export interface NewAccount extends AccountModel {};
-export class Account extends AccountModel {};
+export class Account extends AccountModel {
+};
 export interface Account extends AccountModel {
   id: number;
   email: string;
@@ -641,3 +660,4 @@ type AccountMeta = {
   };
 };
 registerModel(Account);
+

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -397,10 +397,16 @@ declare module "./profile" {
     point: number;
     enabled: boolean;
     role: Role;
+    roleText: string;
     uuid: string;
     cuid: string;
   }
 }
+Object.defineProperty(ProfileModel.prototype, 'roleText', {
+  get() {
+    return Profile.role.values.find(v => v.value == this.role)?.text;
+  }
+});
 export interface NewProfile extends ProfileModel {};
 export class Profile extends ProfileModel {
   static role = new Attribute(this, "Role", Role);

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -403,7 +403,7 @@ declare module "./profile" {
 }
 export interface NewProfile extends ProfileModel {};
 export class Profile extends ProfileModel {
-  static role = new Attribute(ProfileModel, "Role", Role);
+  static role = new Attribute(this, "Role", Role);
 };
 export interface Profile extends ProfileModel {
   id: number;

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -15,6 +15,7 @@ import { EmployeeModel } from './employee.js'
 import { ValidateSampleModel } from './validateSample.js'
 import { AccountModel } from './account.js'
 import {
+  Attribute,
   registerModel,
   type Collection,
   type Filter,
@@ -401,7 +402,9 @@ declare module "./profile" {
   }
 }
 export interface NewProfile extends ProfileModel {};
-export class Profile extends ProfileModel {};
+export class Profile extends ProfileModel {
+  static role = new Attribute(ProfileModel, "Role", Role);
+};
 export interface Profile extends ProfileModel {
   id: number;
   user: User;

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -15,13 +15,15 @@ import { EmployeeModel } from './employee.js'
 import { ValidateSampleModel } from './validateSample.js'
 import { AccountModel } from './account.js'
 import {
-  Attribute,
-  defineEnumTextAttribute,
   registerModel,
   type Collection,
   type Filter,
   type StringFilter,
 } from "accel-record";
+import {
+  Attribute,
+  defineEnumTextAttribute,
+} from "accel-record/enums";
 
 declare module "accel-record" {
   function meta<T>(model: T): Meta<T>;

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -145,7 +145,6 @@ type UserMeta = {
 };
 registerModel(User);
 
-
 declare module "./team" {
   interface TeamModel {
     id: number | undefined;
@@ -189,7 +188,6 @@ type TeamMeta = {
   };
 };
 registerModel(Team);
-
 
 declare module "./userTeam" {
   interface UserTeamModel {
@@ -243,7 +241,6 @@ type UserTeamMeta = {
   };
 };
 registerModel(UserTeam);
-
 
 declare module "./post" {
   interface PostModel {
@@ -305,7 +302,6 @@ type PostMeta = {
 };
 registerModel(Post);
 
-
 declare module "./postTag" {
   interface PostTagModel {
     id: number | undefined;
@@ -349,7 +345,6 @@ type PostTagMeta = {
   };
 };
 registerModel(PostTag);
-
 
 declare module "./setting" {
   interface SettingModel {
@@ -401,7 +396,6 @@ type SettingMeta = {
   };
 };
 registerModel(Setting);
-
 
 declare module "./profile" {
   interface ProfileModel {
@@ -514,7 +508,6 @@ type CompanyMeta = {
 };
 registerModel(Company);
 
-
 declare module "./employee" {
   interface EmployeeModel {
     id: number | undefined;
@@ -559,7 +552,6 @@ type EmployeeMeta = {
   };
 };
 registerModel(Employee);
-
 
 declare module "./validateSample" {
   interface ValidateSampleModel {
@@ -617,7 +609,6 @@ type ValidateSampleMeta = {
 };
 registerModel(ValidateSample);
 
-
 declare module "./account" {
   interface AccountModel {
     id: number | undefined;
@@ -660,4 +651,3 @@ type AccountMeta = {
   };
 };
 registerModel(Account);
-

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -16,6 +16,7 @@ import { ValidateSampleModel } from './validateSample.js'
 import { AccountModel } from './account.js'
 import {
   Attribute,
+  defineEnumTextAttribute,
   registerModel,
   type Collection,
   type Filter,
@@ -402,11 +403,6 @@ declare module "./profile" {
     cuid: string;
   }
 }
-Object.defineProperty(ProfileModel.prototype, 'roleText', {
-  get() {
-    return Profile.role.values.find(v => v.value == this.role)?.text;
-  }
-});
 export interface NewProfile extends ProfileModel {};
 export class Profile extends ProfileModel {
   static role = new Attribute(this, "Role", Role);
@@ -458,6 +454,7 @@ type ProfileMeta = {
   };
 };
 registerModel(Profile);
+defineEnumTextAttribute(ProfileModel, Profile, 'role');
 
 declare module "./company" {
   interface CompanyModel {

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -10,11 +10,11 @@ describe("Enums", (context: any) => {
   if (dbConfig().type == "sqlite") return context.skip();
 
   test("Enums options", () => {
-    expect(Profile.role.values.map((v) => v.value)).toEqual([
+    expect(Profile.role.values().map((v) => v.value)).toEqual([
       "MEMBER",
       "ADMIN",
     ]);
-    expect(Profile.role.values.map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
+    expect(Profile.role.values().map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
     expect(Profile.role.options()).toEqual([
       ["MEMBER", "MEMBER"],
       ["ADMIN", "ADMIN"],
@@ -31,11 +31,11 @@ describe("Enums", (context: any) => {
     withI18n();
 
     test("Enums options", () => {
-      expect(Profile.role.values.map((v) => v.value)).toEqual([
+      expect(Profile.role.values().map((v) => v.value)).toEqual([
         "MEMBER",
         "ADMIN",
       ]);
-      expect(Profile.role.values.map((v) => v.text)).toEqual([
+      expect(Profile.role.values().map((v) => v.text)).toEqual([
         "メンバー",
         "管理者",
       ]);

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -1,4 +1,6 @@
 import { Profile } from ".";
+import { withI18n } from "../contexts/i18n";
+import i18next from "i18next";
 
 test("Enums options", () => {
   expect(Profile.role.values.map((v) => v.value)).toEqual(["MEMBER", "ADMIN"]);
@@ -7,4 +9,57 @@ test("Enums options", () => {
     ["MEMBER", "MEMBER"],
     ["ADMIN", "ADMIN"],
   ]);
+});
+
+describe("with i18n", () => {
+  withI18n();
+
+  test("Enums options", () => {
+    expect(Profile.role.values.map((v) => v.value)).toEqual([
+      "MEMBER",
+      "ADMIN",
+    ]);
+    expect(Profile.role.values.map((v) => v.text)).toEqual([
+      "メンバー",
+      "管理者",
+    ]);
+    expect(Profile.role.options()).toEqual([
+      ["メンバー", "MEMBER"],
+      ["管理者", "ADMIN"],
+    ]);
+  });
+});
+
+describe("with model scoped i18n key", () => {
+  withI18n();
+  beforeEach(() => {
+    i18next.addResources("ja", "translation", {
+      "enums.Profile.Role.MEMBER": "Member",
+      "enums.Profile.Role.ADMIN": "Admin",
+    });
+  });
+
+  test("Enums options", () => {
+    expect(Profile.role.options()).toEqual([
+      ["Member", "MEMBER"],
+      ["Admin", "ADMIN"],
+    ]);
+  });
+});
+
+describe("with defaults scoped i18n key", () => {
+  withI18n();
+  beforeEach(() => {
+    i18next.addResources("ja", "translation", {
+      "enums.defaults.Role.MEMBER": "Member",
+      "enums.defaults.Role.ADMIN": "Admin",
+    });
+  });
+
+  test("Enums options", () => {
+    expect(Profile.role.options()).toEqual([
+      ["Member", "MEMBER"],
+      ["Admin", "ADMIN"],
+    ]);
+  });
 });

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -1,11 +1,13 @@
-import { getConfig } from "accel-record";
 import i18next from "i18next";
 import { Profile } from ".";
 import { withI18n } from "../contexts/i18n";
 import { $Profile } from "../factories/profile";
+import { dbConfig } from "../vitest.setup";
+
+
 
 describe("Enums", (context: any) => {
-  if (getConfig().type === "sqlite") return context.skip();
+  if (dbConfig().type == "sqlite") return context.skip();
 
   test("Enums options", () => {
     expect(Profile.role.values.map((v) => v.value)).toEqual([

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -1,6 +1,7 @@
 import { Profile } from ".";
 import { withI18n } from "../contexts/i18n";
 import i18next from "i18next";
+import { $Profile } from "../factories/profile";
 
 test("Enums options", () => {
   expect(Profile.role.values.map((v) => v.value)).toEqual(["MEMBER", "ADMIN"]);
@@ -9,6 +10,12 @@ test("Enums options", () => {
     ["MEMBER", "MEMBER"],
     ["ADMIN", "ADMIN"],
   ]);
+});
+
+test("enum text", () => {
+  const profile = $Profile.build({ role: "MEMBER" });
+  expect(profile.role).toBe("MEMBER");
+  expect(profile.roleText).toBe("MEMBER");
 });
 
 describe("with i18n", () => {
@@ -28,6 +35,11 @@ describe("with i18n", () => {
       ["管理者", "ADMIN"],
     ]);
   });
+
+  test("enum text", () => {
+    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("メンバー");
+    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("管理者");
+  });
 });
 
 describe("with model scoped i18n key", () => {
@@ -45,6 +57,11 @@ describe("with model scoped i18n key", () => {
       ["Admin", "ADMIN"],
     ]);
   });
+
+  test("enum text", () => {
+    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
+    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
+  });
 });
 
 describe("with defaults scoped i18n key", () => {
@@ -61,5 +78,10 @@ describe("with defaults scoped i18n key", () => {
       ["Member", "MEMBER"],
       ["Admin", "ADMIN"],
     ]);
+  });
+
+  test("enum text", () => {
+    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
+    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
   });
 });

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -4,8 +4,6 @@ import { withI18n } from "../contexts/i18n";
 import { $Profile } from "../factories/profile";
 import { dbConfig } from "../vitest.setup";
 
-
-
 describe("Enums", (context: any) => {
   if (dbConfig().type == "sqlite") return context.skip();
 
@@ -14,7 +12,10 @@ describe("Enums", (context: any) => {
       "MEMBER",
       "ADMIN",
     ]);
-    expect(Profile.role.values().map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
+    expect(Profile.role.values().map((v) => v.text)).toEqual([
+      "MEMBER",
+      "ADMIN",
+    ]);
     expect(Profile.role.options()).toEqual([
       ["MEMBER", "MEMBER"],
       ["ADMIN", "ADMIN"],

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -1,87 +1,95 @@
+import { getConfig } from "accel-record";
+import i18next from "i18next";
 import { Profile } from ".";
 import { withI18n } from "../contexts/i18n";
-import i18next from "i18next";
 import { $Profile } from "../factories/profile";
 
-test("Enums options", () => {
-  expect(Profile.role.values.map((v) => v.value)).toEqual(["MEMBER", "ADMIN"]);
-  expect(Profile.role.values.map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
-  expect(Profile.role.options()).toEqual([
-    ["MEMBER", "MEMBER"],
-    ["ADMIN", "ADMIN"],
-  ]);
-});
-
-test("enum text", () => {
-  const profile = $Profile.build({ role: "MEMBER" });
-  expect(profile.role).toBe("MEMBER");
-  expect(profile.roleText).toBe("MEMBER");
-});
-
-describe("with i18n", () => {
-  withI18n();
+describe("Enums", (context: any) => {
+  if (getConfig().type === "sqlite") return context.skip();
 
   test("Enums options", () => {
     expect(Profile.role.values.map((v) => v.value)).toEqual([
       "MEMBER",
       "ADMIN",
     ]);
-    expect(Profile.role.values.map((v) => v.text)).toEqual([
-      "メンバー",
-      "管理者",
-    ]);
+    expect(Profile.role.values.map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
     expect(Profile.role.options()).toEqual([
-      ["メンバー", "MEMBER"],
-      ["管理者", "ADMIN"],
+      ["MEMBER", "MEMBER"],
+      ["ADMIN", "ADMIN"],
     ]);
   });
 
   test("enum text", () => {
-    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("メンバー");
-    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("管理者");
+    const profile = $Profile.build({ role: "MEMBER" });
+    expect(profile.role).toBe("MEMBER");
+    expect(profile.roleText).toBe("MEMBER");
   });
-});
 
-describe("with model scoped i18n key", () => {
-  withI18n();
-  beforeEach(() => {
-    i18next.addResources("ja", "translation", {
-      "enums.Profile.Role.MEMBER": "Member",
-      "enums.Profile.Role.ADMIN": "Admin",
+  describe("with i18n", () => {
+    withI18n();
+
+    test("Enums options", () => {
+      expect(Profile.role.values.map((v) => v.value)).toEqual([
+        "MEMBER",
+        "ADMIN",
+      ]);
+      expect(Profile.role.values.map((v) => v.text)).toEqual([
+        "メンバー",
+        "管理者",
+      ]);
+      expect(Profile.role.options()).toEqual([
+        ["メンバー", "MEMBER"],
+        ["管理者", "ADMIN"],
+      ]);
+    });
+
+    test("enum text", () => {
+      expect($Profile.build({ role: "MEMBER" }).roleText).toBe("メンバー");
+      expect($Profile.build({ role: "ADMIN" }).roleText).toBe("管理者");
     });
   });
 
-  test("Enums options", () => {
-    expect(Profile.role.options()).toEqual([
-      ["Member", "MEMBER"],
-      ["Admin", "ADMIN"],
-    ]);
-  });
+  describe("with model scoped i18n key", () => {
+    withI18n();
+    beforeEach(() => {
+      i18next.addResources("ja", "translation", {
+        "enums.Profile.Role.MEMBER": "Member",
+        "enums.Profile.Role.ADMIN": "Admin",
+      });
+    });
 
-  test("enum text", () => {
-    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
-    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
-  });
-});
+    test("Enums options", () => {
+      expect(Profile.role.options()).toEqual([
+        ["Member", "MEMBER"],
+        ["Admin", "ADMIN"],
+      ]);
+    });
 
-describe("with defaults scoped i18n key", () => {
-  withI18n();
-  beforeEach(() => {
-    i18next.addResources("ja", "translation", {
-      "enums.defaults.Role.MEMBER": "Member",
-      "enums.defaults.Role.ADMIN": "Admin",
+    test("enum text", () => {
+      expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
+      expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
     });
   });
 
-  test("Enums options", () => {
-    expect(Profile.role.options()).toEqual([
-      ["Member", "MEMBER"],
-      ["Admin", "ADMIN"],
-    ]);
-  });
+  describe("with defaults scoped i18n key", () => {
+    withI18n();
+    beforeEach(() => {
+      i18next.addResources("ja", "translation", {
+        "enums.defaults.Role.MEMBER": "Member",
+        "enums.defaults.Role.ADMIN": "Admin",
+      });
+    });
 
-  test("enum text", () => {
-    expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
-    expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
+    test("Enums options", () => {
+      expect(Profile.role.options()).toEqual([
+        ["Member", "MEMBER"],
+        ["Admin", "ADMIN"],
+      ]);
+    });
+
+    test("enum text", () => {
+      expect($Profile.build({ role: "MEMBER" }).roleText).toBe("Member");
+      expect($Profile.build({ role: "ADMIN" }).roleText).toBe("Admin");
+    });
   });
 });

--- a/tests/models/enums.test.ts
+++ b/tests/models/enums.test.ts
@@ -1,0 +1,10 @@
+import { Profile } from ".";
+
+test("Enums options", () => {
+  expect(Profile.role.values.map((v) => v.value)).toEqual(["MEMBER", "ADMIN"]);
+  expect(Profile.role.values.map((v) => v.text)).toEqual(["MEMBER", "ADMIN"]);
+  expect(Profile.role.options()).toEqual([
+    ["MEMBER", "MEMBER"],
+    ["ADMIN", "ADMIN"],
+  ]);
+});


### PR DESCRIPTION
You can define translations for each value of an Enum.

```ts
// prisma/schema.prisma

enum Role {
  MEMBER
  ADMIN
}

model User {
  /* ... */
  role Role @default(MEMBER)
}
```

You can use `User.role.options()` to retrieve the translations corresponding to each value of the Enum.
For each `User` with a `role`, you can retrieve the translation corresponding to the Enum value using the `roleText` property.

```ts
import i18next from "i18next";
import { User } from "./models/index.js";

i18next
  .init({
    lng: "ja",
    resources: {
      ja: {
        translation: {
          "enums.User.Role.MEMBER": "Member",
          "enums.User.Role.ADMIN": "Admin",
        },
      },
    },
  })
  .then(() => {
    User.role.options(); // => [["Member", "MEMBER"], ["Admin", "ADMIN"]]

    const user = User.build({});
    user.role; // => "MEMBER"
    user.roleText; // => "Member"
  });
```

In the example of `user.role`, the following keys will be searched in order, and the first key found will be used:

```
enums.User.Role.MEMBER
enums.defaults.Role.MEMBER
enums.Role.MEMBER
```