### PR TITLE
Reduce unnecessary query execution when including hasMany association.

### DIFF
--- a/packages/accel-record-core/src/associations/modelInstanceBuilder.ts
+++ b/packages/accel-record-core/src/associations/modelInstanceBuilder.ts
@@ -31,9 +31,12 @@ export class ModelInstanceBuilder {
     }
     this.initAssociations<T>(klass, instance);
     // Updating fields other than the column field
-    Object.keys(input).forEach((key) => {
-      if (klass.attributeToColumn(key) == undefined) {
-        proxy[key] = input[key];
+    Object.entries(input).forEach(([key, value]) => {
+      const v = (instance as any)[key];
+      if (v instanceof Collection && Array.isArray(value)) {
+        (v as any).cache = value;
+      } else if (klass.attributeToColumn(key) == undefined) {
+        proxy[key] = value;
       }
     });
     return proxy;

--- a/tests/models/hasMany.test.ts
+++ b/tests/models/hasMany.test.ts
@@ -46,7 +46,10 @@ describe("ManyToMany", () => {
   test("includes", () => {
     $user.create({ posts: [$post.build()] });
 
+    const baseCount = User.connection.queryCount;
     const user = User.includes("posts").first()!;
+    expect(User.connection.queryCount - baseCount).toBe(2);
+
     const beforeCount = User.connection.queryCount;
     expect(user.posts.toArray().length).toBe(1);
     expect(User.connection.queryCount).toBe(beforeCount);


### PR DESCRIPTION
I reduced unnecessary query execution when specifying hasMany association in includes.

### Example

```ts
User.includes("posts").first()
```
**Queries before**
```sql
select `User`.* from `User` order by `id` asc limit 1
select `Post`.* from `Post` where `Post`.`author_id` in (?)
select `Post`.* from `Post` where `author_id` = ? # unecessary
select `Post`.* from `Post` where `author_id` = ? # unecessary
select `Post`.* from `Post` where `author_id` = ? # unecessary
```

**Queries after**
```sql
select `User`.* from `User` order by `id` asc limit 1
select `Post`.* from `Post` where `Post`.`author_id` in (?)
```