### PR TITLE
Support for Composite IDs

### DIFF
--- a/packages/accel-record-core/src/associations/association.ts
+++ b/packages/accel-record-core/src/associations/association.ts
@@ -22,20 +22,13 @@ export class Association<O extends Model, T extends Model> {
   scopeAttributes() {
     const ret: any = {};
     for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
-      ret[this.info.foreignKeyColumns[i]] =
-        this.owner[this.info.primaryKeyColumns[i] as keyof O];
+      ret[this.info.foreignKeyColumns[i]] = this.owner[this.info.primaryKeyColumns[i] as keyof O];
     }
     return ret;
   }
 
   get ownerHasPrimary() {
-    return this.info.primaryKeyColumns.every(
-      (col) => this.owner[col as keyof O] !== undefined
-    );
-  }
-
-  get ownersPrimary() {
-    return this.owner[this.info.primaryKey as keyof O];
+    return this.info.primaryKeyColumns.every((col) => this.owner[col as keyof O] !== undefined);
   }
 
   protected get connection() {

--- a/packages/accel-record-core/src/associations/association.ts
+++ b/packages/accel-record-core/src/associations/association.ts
@@ -28,6 +28,12 @@ export class Association<O extends Model, T extends Model> {
     return ret;
   }
 
+  get ownerHasPrimary() {
+    return this.info.primaryKeyColumns.every(
+      (col) => this.owner[col as keyof O] !== undefined
+    );
+  }
+
   get ownersPrimary() {
     return this.owner[this.info.primaryKey as keyof O];
   }

--- a/packages/accel-record-core/src/associations/association.ts
+++ b/packages/accel-record-core/src/associations/association.ts
@@ -20,11 +20,10 @@ export class Association<O extends Model, T extends Model> {
   }
 
   scopeAttributes() {
-    const ret: any = {};
-    for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
-      ret[this.info.foreignKeyColumns[i]] = this.owner[this.info.primaryKeyColumns[i] as keyof O];
-    }
-    return ret;
+    return this.info.foreignKeyColumns.toHash((col, i) => [
+      col,
+      this.owner[this.info.primaryKeyColumns[i] as keyof O],
+    ]);
   }
 
   get ownerHasPrimary() {

--- a/packages/accel-record-core/src/associations/association.ts
+++ b/packages/accel-record-core/src/associations/association.ts
@@ -20,7 +20,12 @@ export class Association<O extends Model, T extends Model> {
   }
 
   scopeAttributes() {
-    return { [this.info.foreignKey]: this.ownersPrimary };
+    const ret: any = {};
+    for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
+      ret[this.info.foreignKeyColumns[i]] =
+        this.owner[this.info.primaryKeyColumns[i] as keyof O];
+    }
+    return ret;
   }
 
   get ownersPrimary() {

--- a/packages/accel-record-core/src/associations/belongsToAssociation.ts
+++ b/packages/accel-record-core/src/associations/belongsToAssociation.ts
@@ -24,10 +24,9 @@ export class BelongsToAssociation<O extends Model, T extends Model> extends Asso
   }
 
   override scopeAttributes() {
-    const ret: any = {};
-    for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
-      ret[this.info.primaryKeyColumns[i]] = this.owner[this.info.foreignKeyColumns[i] as keyof O];
-    }
-    return ret;
+    return this.info.primaryKeyColumns.toHash((col, i) => [
+      col,
+      this.owner[this.info.foreignKeyColumns[i] as keyof O],
+    ]);
   }
 }

--- a/packages/accel-record-core/src/associations/belongsToAssociation.ts
+++ b/packages/accel-record-core/src/associations/belongsToAssociation.ts
@@ -15,13 +15,19 @@ export class BelongsToAssociation<O extends Model, T extends Model> extends Asso
 
   setter(record: T) {
     this.target = record;
-    this.owner[this.info.foreignKey as keyof O] = record[this.info.primaryKey as keyof T] as any;
+    for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
+      this.owner[this.info.foreignKeyColumns[i] as keyof O] = record[
+        this.info.primaryKeyColumns[i] as keyof T
+      ] as any;
+    }
     this.isLoaded = true;
   }
 
   override scopeAttributes() {
-    return {
-      [this.info.primaryKey]: this.owner[this.info.foreignKey as keyof O],
-    };
+    const ret: any = {};
+    for (let i = 0; i < this.info.foreignKeyColumns.length; i++) {
+      ret[this.info.primaryKeyColumns[i]] = this.owner[this.info.foreignKeyColumns[i] as keyof O];
+    }
+    return ret;
   }
 }

--- a/packages/accel-record-core/src/associations/hasManyThroughAssociation.ts
+++ b/packages/accel-record-core/src/associations/hasManyThroughAssociation.ts
@@ -66,9 +66,13 @@ export class HasManyThroughAssociation<O extends Model, T extends Model> extends
       joins: [
         [
           this.info.through,
-          `${this.info.field.type}.${this.info.primaryKey}`,
-          "=",
-          `${this.info.through}.${this.joinKey}`,
+          [
+            [
+              `${this.info.field.type}.${this.info.primaryKey}`,
+              "=",
+              `${this.info.through}.${this.joinKey}`,
+            ],
+          ],
         ],
       ],
       wheres: [

--- a/packages/accel-record-core/src/associations/hasManyThroughAssociation.ts
+++ b/packages/accel-record-core/src/associations/hasManyThroughAssociation.ts
@@ -92,4 +92,8 @@ export class HasManyThroughAssociation<O extends Model, T extends Model> extends
   private get joinKey() {
     return this.info.joinKey;
   }
+
+  get ownersPrimary() {
+    return this.owner[this.info.primaryKey as keyof O];
+  }
 }

--- a/packages/accel-record-core/src/model/association.ts
+++ b/packages/accel-record-core/src/model/association.ts
@@ -26,8 +26,8 @@ export class Association {
     relation: DMMF.Field,
     association: Field,
     primaryKeys: readonly string[],
-    foreignKeyColumns: string[],
-    primaryKeyColumns: string[]
+    public foreignKeyColumns: string[],
+    public primaryKeyColumns: string[]
   ) {
     this.klass = association.type;
     this.foreignKey = foreignKeyColumns[0] ?? "";

--- a/packages/accel-record-core/src/relation/association.ts
+++ b/packages/accel-record-core/src/relation/association.ts
@@ -97,8 +97,8 @@ export class Association {
   protected hasManyThroughJoins<T>(this: Relation<T, ModelMeta>, info: Info) {
     const { through, model, primaryKey, foreignKey, joinKey } = info;
     return [
-      [through, `${through}.${foreignKey}`, "=", `${this.model.tableName}.${primaryKey}`],
-      [model.tableName, `${through}.${joinKey}`, "=", `${model.tableName}.${info.primaryKey}`],
+      [through, [[`${through}.${foreignKey}`, "=", `${this.model.tableName}.${primaryKey}`]]],
+      [model.tableName, [[`${through}.${joinKey}`, "=", `${model.tableName}.${info.primaryKey}`]]],
     ];
   }
 

--- a/packages/accel-record-core/src/relation/association.ts
+++ b/packages/accel-record-core/src/relation/association.ts
@@ -72,9 +72,11 @@ export class Association {
     return [
       [
         info.model.tableName,
-        `${this.model.tableName}.${info.primaryKey}`,
-        "=",
-        `${info.model.tableName}.${info.foreignKey}`,
+        info.primaryKeyColumns.map((column, index) => [
+          `${this.model.tableName}.${column}`,
+          "=",
+          `${info.model.tableName}.${info.foreignKeyColumns[index]}`,
+        ]),
       ],
     ];
   }
@@ -83,9 +85,11 @@ export class Association {
     return [
       [
         info.model.tableName,
-        `${info.model.tableName}.${info.primaryKey}`,
-        "=",
-        `${this.model.tableName}.${info.foreignKey}`,
+        info.primaryKeyColumns.map((column, index) => [
+          `${info.model.tableName}.${column}`,
+          "=",
+          `${this.model.tableName}.${info.foreignKeyColumns[index]}`,
+        ]),
       ],
     ];
   }
@@ -117,11 +121,7 @@ export class Association {
 }
 
 function alreadyContains(arrays: any[][], targetArray: any[]): boolean {
-  return arrays.some(
-    (array) =>
-      array.length === targetArray.length &&
-      array.every((value, index) => value === targetArray[index])
-  );
+  return arrays.some((array) => array[0] === targetArray[0]);
 }
 
 function formatJoinsInput(...input: any[]): object {

--- a/packages/accel-record-core/src/relation/base.ts
+++ b/packages/accel-record-core/src/relation/base.ts
@@ -53,7 +53,14 @@ export class RelationBase {
   protected query<T>(this: Relation<T, ModelMeta>) {
     let q = this.model.queryBuilder.clone() as any;
     for (const join of this.options.joins) {
-      q = q.join(...join);
+      if (Array.isArray(join[1])) {
+        q = q.join(join[0], function (this: any) {
+          for (const j of join[1]) this.on(...j);
+        });
+      } else {
+        // TODO: remove this branch
+        q = q.join(...join);
+      }
     }
     for (const [query, bindings] of this.options.joinsRaw) {
       q = q.joinRaw(query, bindings);

--- a/packages/accel-record-core/src/relation/base.ts
+++ b/packages/accel-record-core/src/relation/base.ts
@@ -12,6 +12,12 @@ import { Options } from "./options.js";
  * This class is intended to be inherited by the Relation class.
  */
 export class RelationBase {
+  reset<T>(this: Relation<T, ModelMeta>) {
+    this.cache = undefined;
+    this.counter = 0;
+    return this;
+  }
+
   setOption<T>(this: Relation<T, ModelMeta>, key: keyof Options, value: any) {
     (this.options as any)[key] = value;
     return this;

--- a/packages/accel-record-core/src/relation/base.ts
+++ b/packages/accel-record-core/src/relation/base.ts
@@ -53,14 +53,9 @@ export class RelationBase {
   protected query<T>(this: Relation<T, ModelMeta>) {
     let q = this.model.queryBuilder.clone() as any;
     for (const join of this.options.joins) {
-      if (Array.isArray(join[1])) {
-        q = q.join(join[0], function (this: any) {
-          for (const j of join[1]) this.on(...j);
-        });
-      } else {
-        // TODO: remove this branch
-        q = q.join(...join);
-      }
+      q = q.join(join[0], function (this: any) {
+        for (const j of join[1]) this.on(...j);
+      });
     }
     for (const [query, bindings] of this.options.joinsRaw) {
       q = q.joinRaw(query, bindings);

--- a/packages/accel-record-core/src/relation/query.ts
+++ b/packages/accel-record-core/src/relation/query.ts
@@ -10,12 +10,6 @@ import { Relation, Relations } from "./index.js";
  * This class is intended to be inherited by the Relation class.
  */
 export class Query {
-  reset<T>(this: Relation<T, ModelMeta>) {
-    this.cache = undefined;
-    this.counter = 0;
-    return this;
-  }
-
   /**
    * Finds a record by its ID.
    * @param id - The ID of the record.

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -407,7 +407,7 @@ Accel Recordはスキーマ定義にPrismaを利用していますが、各機�
 | 機能                            | 記法        | サポート |
 | ------------------------------- | ----------- | -------- |
 | ID                              | @id         | ✅       |
-| Multi-field ID (Composite ID)   | @@id        | -        |
+| Multi-field ID (Composite ID)   | @@id        | ✅       |
 | Table name mapping              | @@map       | ✅       |
 | Column name mapping             | @map        | ✅       |
 | Default value                   | @default    | ✅       |
@@ -842,12 +842,7 @@ Vitestを使ったテストでは、以下のようなsetupファイルを用意
 ```ts
 // tests/vitest.setup.ts
 
-import {
-  DatabaseCleaner,
-  Migration,
-  initAccelRecord,
-  stopWorker,
-} from "accel-record";
+import { DatabaseCleaner, Migration, initAccelRecord, stopWorker } from "accel-record";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -1402,6 +1397,4 @@ user.update({ age: undefined });
 
 ## 今後予定されている機能追加
 
-- [accel-record-core] 複合IDの対応
-
-関連: [Accel Record Roadmap](https://github.com/koyopro/accella/issues/1)
+[Accel Record Roadmap](https://github.com/koyopro/accella/issues/1)

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -406,7 +406,7 @@ Accel Record uses Prisma for schema definition, and the support status for each 
 | Feature                         | Notation    | Support |
 | ------------------------------- | ----------- | ------- |
 | ID                              | @id         | ✅      |
-| Multi-field ID (Composite ID)   | @@id        | -       |
+| Multi-field ID (Composite ID)   | @@id        | ✅      |
 | Table name mapping              | @@map       | ✅      |
 | Column name mapping             | @map        | ✅      |
 | Default value                   | @default    | ✅      |
@@ -841,12 +841,7 @@ In Vitest, you prepare a setup file like the following for testing.
 ```ts
 // tests/vitest.setup.ts
 
-import {
-  DatabaseCleaner,
-  Migration,
-  initAccelRecord,
-  stopWorker,
-} from "accel-record";
+import { DatabaseCleaner, Migration, initAccelRecord, stopWorker } from "accel-record";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -1401,6 +1396,4 @@ user.update({ age: undefined });
 
 ## Future Planned Features
 
-- [accel-record-core] Support for Composite IDs
-
-Related: [Accel Record Roadmap](https://github.com/koyopro/accella/issues/1)
+[Accel Record Roadmap](https://github.com/koyopro/accella/issues/1)

--- a/tests/factories/author.ts
+++ b/tests/factories/author.ts
@@ -1,0 +1,9 @@
+import { defineFactory } from "accel-record-factory";
+import { Author } from "../models/index.js";
+
+export const AuthorFactory = defineFactory(Author, {
+  // firstName: "MyString",
+  // lastName: "MyString"
+});
+
+export { AuthorFactory as $Author };

--- a/tests/factories/book.ts
+++ b/tests/factories/book.ts
@@ -1,0 +1,10 @@
+import { defineFactory } from "accel-record-factory";
+import { Book } from "../models/index.js";
+
+export const BookFactory = defineFactory(Book, {
+  // title: "MyString",
+  // authorFirstName: "MyString",
+  // authorLastName: "MyString"
+});
+
+export { BookFactory as $Book };

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -671,8 +671,8 @@ declare module "./author" {
   interface AuthorModel {
     firstName: string | undefined;
     lastName: string | undefined;
-    get Book(): BookCollection<BookModel>;
-    set Book(value: BookModel[]);
+    get books(): BookCollection<BookModel>;
+    set books(value: BookModel[]);
   }
 }
 export interface NewAuthor extends AuthorModel {};
@@ -681,10 +681,10 @@ export class Author extends AuthorModel {
 export interface Author extends AuthorModel {
   firstName: string;
   lastName: string;
-  get Book(): BookCollection<Book>;
-  set Book(value: BookModel[]);
+  get books(): BookCollection<Book>;
+  set books(value: BookModel[]);
 };
-type AuthorAssociationKey = 'Book';
+type AuthorAssociationKey = 'books';
 type AuthorCollection<T extends AuthorModel> = Collection<T, AuthorMeta> | Collection<Author, AuthorMeta>;
 type AuthorMeta = {
   Base: AuthorModel;
@@ -693,7 +693,7 @@ type AuthorMeta = {
   PrimaryKey: [string, string];
   AssociationKey: AuthorAssociationKey;
   JoinInput: AuthorAssociationKey | AuthorAssociationKey[] | {
-    Book?: Meta<Book>['JoinInput'];
+    books?: Meta<Book>['JoinInput'];
   };
   Column: {
     firstName: string;
@@ -702,12 +702,12 @@ type AuthorMeta = {
   CreateInput: {
     firstName: string;
     lastName: string;
-    Book?: BookModel[];
+    books?: BookModel[];
   };
   WhereInput: {
     firstName?: string | string[] | StringFilter | null;
     lastName?: string | string[] | StringFilter | null;
-    Book?: BookMeta['WhereInput'];
+    books?: BookMeta['WhereInput'];
   };
 };
 registerModel(Author);

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -14,6 +14,8 @@ import { CompanyModel } from './company.js'
 import { EmployeeModel } from './employee.js'
 import { ValidateSampleModel } from './validateSample.js'
 import { AccountModel } from './account.js'
+import { AuthorModel } from './author.js'
+import { BookModel } from './book.js'
 import {
   registerModel,
   type Collection,
@@ -45,6 +47,8 @@ type Meta<T> = T extends typeof UserModel | UserModel ? UserMeta :
                T extends typeof EmployeeModel | EmployeeModel ? EmployeeMeta :
                T extends typeof ValidateSampleModel | ValidateSampleModel ? ValidateSampleMeta :
                T extends typeof AccountModel | AccountModel ? AccountMeta :
+               T extends typeof AuthorModel | AuthorModel ? AuthorMeta :
+               T extends typeof BookModel | BookModel ? BookMeta :
                any;
 
 export namespace $Enums {
@@ -662,3 +666,96 @@ type AccountMeta = {
   };
 };
 registerModel(Account);
+
+declare module "./author" {
+  interface AuthorModel {
+    firstName: string | undefined;
+    lastName: string | undefined;
+    get Book(): BookCollection<BookModel>;
+    set Book(value: BookModel[]);
+  }
+}
+export interface NewAuthor extends AuthorModel {};
+export class Author extends AuthorModel {};
+export interface Author extends AuthorModel {
+  firstName: string;
+  lastName: string;
+  get Book(): BookCollection<Book>;
+  set Book(value: BookModel[]);
+};
+type AuthorAssociationKey = 'Book';
+type AuthorCollection<T extends AuthorModel> = Collection<T, AuthorMeta> | Collection<Author, AuthorMeta>;
+type AuthorMeta = {
+  Base: AuthorModel;
+  New: NewAuthor;
+  Persisted: Author;
+  PrimaryKeys: [string, string];
+  AssociationKey: AuthorAssociationKey;
+  JoinInput: AuthorAssociationKey | AuthorAssociationKey[] | {
+    Book?: Meta<Book>['JoinInput'];
+  };
+  Column: {
+    firstName: string;
+    lastName: string;
+  };
+  CreateInput: {
+    firstName: string;
+    lastName: string;
+    Book?: BookModel[];
+  };
+  WhereInput: {
+    firstName?: string | string[] | StringFilter | null;
+    lastName?: string | string[] | StringFilter | null;
+    Book?: BookMeta['WhereInput'];
+  };
+};
+registerModel(Author);
+
+declare module "./book" {
+  interface BookModel {
+    id: number | undefined;
+    title: string | undefined;
+    author: Author | undefined;
+    authorFirstName: string | undefined;
+    authorLastName: string | undefined;
+  }
+}
+export interface NewBook extends BookModel {};
+export class Book extends BookModel {};
+export interface Book extends BookModel {
+  id: number;
+  title: string;
+  author: Author;
+  authorFirstName: string;
+  authorLastName: string;
+};
+type BookAssociationKey = 'author';
+type BookCollection<T extends BookModel> = Collection<T, BookMeta> | Collection<Book, BookMeta>;
+type BookMeta = {
+  Base: BookModel;
+  New: NewBook;
+  Persisted: Book;
+  PrimaryKeys: [number];
+  AssociationKey: BookAssociationKey;
+  JoinInput: BookAssociationKey | BookAssociationKey[] | {
+    author?: Meta<Author>['JoinInput'];
+  };
+  Column: {
+    id: number;
+    title: string;
+    authorFirstName: string;
+    authorLastName: string;
+  };
+  CreateInput: {
+    id?: number;
+    title: string;
+  } & ({ author: Author } | { authorFirstName: string, authorLastName: string });
+  WhereInput: {
+    id?: number | number[] | Filter<number> | null;
+    title?: string | string[] | StringFilter | null;
+    author?: Author | Author[] | AuthorMeta['WhereInput'];
+    authorFirstName?: string | string[] | StringFilter | null;
+    authorLastName?: string | string[] | StringFilter | null;
+  };
+};
+registerModel(Book);

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -676,7 +676,8 @@ declare module "./author" {
   }
 }
 export interface NewAuthor extends AuthorModel {};
-export class Author extends AuthorModel {};
+export class Author extends AuthorModel {
+};
 export interface Author extends AuthorModel {
   firstName: string;
   lastName: string;
@@ -689,7 +690,7 @@ type AuthorMeta = {
   Base: AuthorModel;
   New: NewAuthor;
   Persisted: Author;
-  PrimaryKeys: [string, string];
+  PrimaryKey: [string, string];
   AssociationKey: AuthorAssociationKey;
   JoinInput: AuthorAssociationKey | AuthorAssociationKey[] | {
     Book?: Meta<Book>['JoinInput'];
@@ -721,7 +722,8 @@ declare module "./book" {
   }
 }
 export interface NewBook extends BookModel {};
-export class Book extends BookModel {};
+export class Book extends BookModel {
+};
 export interface Book extends BookModel {
   id: number;
   title: string;
@@ -735,7 +737,7 @@ type BookMeta = {
   Base: BookModel;
   New: NewBook;
   Persisted: Book;
-  PrimaryKeys: [number];
+  PrimaryKey: number;
   AssociationKey: BookAssociationKey;
   JoinInput: BookAssociationKey | BookAssociationKey[] | {
     author?: Meta<Author>['JoinInput'];

--- a/tests/models/author.ts
+++ b/tests/models/author.ts
@@ -1,5 +1,3 @@
 import { ApplicationRecord } from "./applicationRecord.js";
 
-export class AuthorModel extends ApplicationRecord {
-
-}
+export class AuthorModel extends ApplicationRecord {}

--- a/tests/models/author.ts
+++ b/tests/models/author.ts
@@ -1,0 +1,5 @@
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class AuthorModel extends ApplicationRecord {
+
+}

--- a/tests/models/book.ts
+++ b/tests/models/book.ts
@@ -1,5 +1,3 @@
 import { ApplicationRecord } from "./applicationRecord.js";
 
-export class BookModel extends ApplicationRecord {
-
-}
+export class BookModel extends ApplicationRecord {}

--- a/tests/models/book.ts
+++ b/tests/models/book.ts
@@ -1,0 +1,5 @@
+import { ApplicationRecord } from "./applicationRecord.js";
+
+export class BookModel extends ApplicationRecord {
+
+}

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -1,4 +1,4 @@
-import { Book, UserTeam } from ".";
+import { Author, Book, UserTeam } from ".";
 import { $Author } from "../factories/author";
 import { $Book } from "../factories/book";
 import { $team } from "../factories/team";
@@ -17,11 +17,18 @@ test("find()", () => {
 });
 
 test("relation()", () => {
-  $Author.create({ firstName: "Jane", lastName: "A" });
+  const auther0 = $Author.create({ firstName: "Jane", lastName: "A" });
+  $Book.create({ title: "Book2", author: auther0 });
   $Author.create({ firstName: "Jane", lastName: "Z" });
   const author = $Author.create({ firstName: "Jane", lastName: "Doe" });
   const book = $Book.create({ title: "Book1", author });
   expect(book.reload().author.lastName).toBe("Doe");
 
   expect(Book.includes("author").find(book.id).author.lastName).toBe("Doe");
+
+  const authors = Author.includes("Book").toArray();
+  expect(authors.length).toBe(3);
+  expect((authors[0].Book as any).cache.length).toBe(1);
+  expect((authors[1].Book as any).cache.length).toBe(1);
+  expect((authors[2].Book as any).cache.length).toBe(0);
 });

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -1,4 +1,6 @@
 import { UserTeam } from ".";
+import { $Author } from "../factories/author";
+import { $Book } from "../factories/book";
 import { $team } from "../factories/team";
 import { $user } from "../factories/user";
 import { $UserTeam } from "../factories/userTeam";
@@ -12,4 +14,11 @@ test("find()", () => {
   expect(ut.reload().assignedBy).toBe("text1");
   expect(ut.primaryKeys).toEqual(["userId", "teamId"]);
   expect(UserTeam.find([ut.userId, ut.teamId]).assignedBy).toBe("text1");
+});
+
+test("relation()", () => {
+  $Author.create({ firstName: "Jane", lastName: "A" });
+  const author = $Author.create({ firstName: "Jane", lastName: "Doe" });
+  const book = $Book.create({ title: "Book1", author });
+  expect(book.reload().author.lastName).toBe("Doe");
 });

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -32,3 +32,13 @@ test("relation()", () => {
   expect((authors[1].Book as any).cache.length).toBe(1);
   expect((authors[2].Book as any).cache.length).toBe(0);
 });
+
+test("joins", () => {
+  const author0 = $Author.create({ firstName: "Jane", lastName: "A" });
+  $Book.create({ title: "Book0", author: author0 });
+  const author = $Author.create({ firstName: "Jane", lastName: "Doe" });
+  $Book.create({ title: "Book1", author });
+
+  expect(Book.joins("author").count()).toBe(2);
+  expect(Author.joins("Book").count()).toBe(2);
+});

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -1,4 +1,4 @@
-import { UserTeam } from ".";
+import { Book, UserTeam } from ".";
 import { $Author } from "../factories/author";
 import { $Book } from "../factories/book";
 import { $team } from "../factories/team";
@@ -18,7 +18,10 @@ test("find()", () => {
 
 test("relation()", () => {
   $Author.create({ firstName: "Jane", lastName: "A" });
+  $Author.create({ firstName: "Jane", lastName: "Z" });
   const author = $Author.create({ firstName: "Jane", lastName: "Doe" });
   const book = $Book.create({ title: "Book1", author });
   expect(book.reload().author.lastName).toBe("Doe");
+
+  expect(Book.includes("author").find(book.id).author.lastName).toBe("Doe");
 });

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -26,11 +26,11 @@ test("relation()", () => {
 
   expect(Book.includes("author").find(book.id).author.lastName).toBe("Doe");
 
-  const authors = Author.includes("Book").toArray();
+  const authors = Author.includes("books").toArray();
   expect(authors.length).toBe(3);
-  expect((authors[0].Book as any).cache.length).toBe(1);
-  expect((authors[1].Book as any).cache.length).toBe(1);
-  expect((authors[2].Book as any).cache.length).toBe(0);
+  expect((authors[0].books as any).cache.length).toBe(1);
+  expect((authors[1].books as any).cache.length).toBe(1);
+  expect((authors[2].books as any).cache.length).toBe(0);
 });
 
 test("joins", () => {
@@ -40,5 +40,5 @@ test("joins", () => {
   $Book.create({ title: "Book1", author });
 
   expect(Book.joins("author").count()).toBe(2);
-  expect(Author.joins("Book").count()).toBe(2);
+  expect(Author.joins("books").count()).toBe(2);
 });

--- a/tests/models/compositeIds.test.ts
+++ b/tests/models/compositeIds.test.ts
@@ -26,7 +26,7 @@ test("relation()", () => {
 
   expect(Book.includes("author").find(book.id).author.lastName).toBe("Doe");
 
-  const authors = Author.includes("books").toArray();
+  const authors = Author.includes("books").order("lastName").toArray();
   expect(authors.length).toBe(3);
   expect((authors[0].books as any).cache.length).toBe(1);
   expect((authors[1].books as any).cache.length).toBe(1);

--- a/tests/prisma/migrations/20240827172338_add_author_and_book/migration.sql
+++ b/tests/prisma/migrations/20240827172338_add_author_and_book/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Author" (
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+
+    PRIMARY KEY ("firstName", "lastName")
+);
+
+-- CreateTable
+CREATE TABLE "Book" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "authorFirstName" TEXT NOT NULL,
+    "authorLastName" TEXT NOT NULL,
+    CONSTRAINT "Book_authorFirstName_authorLastName_fkey" FOREIGN KEY ("authorFirstName", "authorLastName") REFERENCES "Author" ("firstName", "lastName") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -110,3 +110,19 @@ model Account {
   email          String  @unique
   passwordDigest String?
 }
+
+model Author {
+  firstName String
+  lastName  String
+  books     Book[]
+
+  @@id([firstName, lastName])
+}
+
+model Book {
+  id              Int    @id @default(autoincrement())
+  title           String
+  author          Author @relation(fields: [authorFirstName, authorLastName], references: [firstName, lastName])
+  authorFirstName String
+  authorLastName  String
+}

--- a/tests/prisma_mysql/migrations/20240819173628_add_author_and_book/migration.sql
+++ b/tests/prisma_mysql/migrations/20240819173628_add_author_and_book/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE `Author` (
+    `firstName` VARCHAR(191) NOT NULL,
+    `lastName` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`firstName`, `lastName`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Book` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(191) NOT NULL,
+    `authorFirstName` VARCHAR(191) NOT NULL,
+    `authorLastName` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Book` ADD CONSTRAINT `Book_authorFirstName_authorLastName_fkey` FOREIGN KEY (`authorFirstName`, `authorLastName`) REFERENCES `Author`(`firstName`, `lastName`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/tests/prisma_mysql/schema.prisma
+++ b/tests/prisma_mysql/schema.prisma
@@ -116,3 +116,19 @@ model Account {
   email          String @unique
   passwordDigest String
 }
+
+model Author {
+  firstName String
+  lastName  String
+  Book      Book[]
+
+  @@id([firstName, lastName])
+}
+
+model Book {
+  id              Int    @id @default(autoincrement())
+  title           String
+  author          Author @relation(fields: [authorFirstName, authorLastName], references: [firstName, lastName])
+  authorFirstName String
+  authorLastName  String
+}

--- a/tests/prisma_mysql/schema.prisma
+++ b/tests/prisma_mysql/schema.prisma
@@ -120,7 +120,7 @@ model Account {
 model Author {
   firstName String
   lastName  String
-  Book      Book[]
+  books     Book[]
 
   @@id([firstName, lastName])
 }

--- a/tests/prisma_pg/migrations/20240827172351_add_author_and_book/migration.sql
+++ b/tests/prisma_pg/migrations/20240827172351_add_author_and_book/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Author" (
+    "firstName" TEXT NOT NULL,
+    "lastName" TEXT NOT NULL,
+
+    CONSTRAINT "Author_pkey" PRIMARY KEY ("firstName","lastName")
+);
+
+-- CreateTable
+CREATE TABLE "Book" (
+    "id" SERIAL NOT NULL,
+    "title" TEXT NOT NULL,
+    "authorFirstName" TEXT NOT NULL,
+    "authorLastName" TEXT NOT NULL,
+
+    CONSTRAINT "Book_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Book" ADD CONSTRAINT "Book_authorFirstName_authorLastName_fkey" FOREIGN KEY ("authorFirstName", "authorLastName") REFERENCES "Author"("firstName", "lastName") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/tests/prisma_pg/schema.prisma
+++ b/tests/prisma_pg/schema.prisma
@@ -116,3 +116,19 @@ model Account {
   email          String  @unique
   passwordDigest String?
 }
+
+model Author {
+  firstName String
+  lastName  String
+  books     Book[]
+
+  @@id([firstName, lastName])
+}
+
+model Book {
+  id              Int    @id @default(autoincrement())
+  title           String
+  author          Author @relation(fields: [authorFirstName, authorLastName], references: [firstName, lastName])
+  authorFirstName String
+  authorLastName  String
+}


### PR DESCRIPTION
Now you can work with models that have composite IDs.

In the following example, the `Author` model has a composite ID, and the `Book` model references the `Author` model.
```prisma
// prisma/schema.prisma

model Author {
  firstName String
  lastName  String
  books     Book[]
  @@id([firstName, lastName]) // Composite ID
}

model Book {
  id              Int    @id @default(autoincrement())
  title           String
  author          Author @relation(fields: [authorFirstName, authorLastName], references: [firstName, lastName])
  authorFirstName String
  authorLastName  String
}
```

Even with models that have composite IDs, methods like find(), joins(), and retrieving associations work as expected.

```ts
// find
const author = Auther.find(['John', 'Doe'])

// associations
const books = author.books

// joins
Author.joins('books').where({ books: { title: 'Book 1' } })
```