### PR TITLE
add NumericalityValidator

### DIFF
--- a/packages/accel-record-core/src/model/validations.ts
+++ b/packages/accel-record-core/src/model/validations.ts
@@ -9,6 +9,10 @@ import { FormatOptions, FormatValidator } from "../validation/validator/format.j
 import { InclusionOptions, InclusionValidator } from "../validation/validator/inclusion.js";
 import { Validator } from "../validation/validator/index.js";
 import { LengthOptions, LengthValidator } from "../validation/validator/length.js";
+import {
+  NumericalityOptions,
+  NumericalityValidator,
+} from "../validation/validator/numericality.js";
 import { PresenceOptions, PresenceValidator } from "../validation/validator/presence.js";
 import { UniquenessValidator, UniqunessOptions } from "../validation/validator/uniqueness.js";
 
@@ -19,6 +23,7 @@ type ValidatesOptions<T> = {
   inclusion?: InclusionOptions;
   format?: FormatOptions;
   uniqueness?: UniqunessOptions<T>;
+  numericality?: NumericalityOptions;
 };
 
 /**
@@ -124,6 +129,9 @@ export class Validations {
 
       if (options.uniqueness)
         new UniquenessValidator(this, attribute, options.uniqueness).validate();
+
+      if (options.numericality)
+        new NumericalityValidator(this, attribute, options.numericality).validate();
     }
   }
 }

--- a/packages/accel-record-core/src/validation/errors.ts
+++ b/packages/accel-record-core/src/validation/errors.ts
@@ -10,6 +10,17 @@ const defaultMessages: Record<string, string | undefined> = {
   tooLong: "is too long (maximum is %{count} characters)",
   taken: "has already been taken",
   confirmation: "doesn't match %{attribute}",
+
+  notANumber: "is not a number",
+  notAnInteger: "must be an integer",
+  equalTo: "must be equal to %{count}",
+  greaterThan: "must be greater than %{count}",
+  greaterThanOrEqualTo: "must be greater than or equal to %{count}",
+  lessThan: "must be less than %{count}",
+  lessThanOrEqualTo: "must be less than or equal to %{count}",
+  otherThan: "must be other than %{count}",
+  odd: "must be odd",
+  even: "must be even",
 };
 
 type Options = { count?: number; attribute?: string };
@@ -41,7 +52,7 @@ export class Error {
 
   get message() {
     let message = this.translatedMessage;
-    if (this.options.count) {
+    if (this.options.count != undefined) {
       message = message.replace("%{count}", this.options.count.toString());
     }
     if (message.includes("%{attribute}")) {

--- a/packages/accel-record-core/src/validation/errors.ts
+++ b/packages/accel-record-core/src/validation/errors.ts
@@ -18,12 +18,13 @@ const defaultMessages: Record<string, string | undefined> = {
   greaterThanOrEqualTo: "must be greater than or equal to {{count}}",
   lessThan: "must be less than {{count}}",
   lessThanOrEqualTo: "must be less than or equal to {{count}}",
+  between: "must be between {{min}} and {{max}}",
   otherThan: "must be other than {{count}}",
   odd: "must be odd",
   even: "must be even",
 };
 
-type Options = { count?: number; attribute?: string };
+type Options = Record<string, number | string | undefined>;
 
 /**
  * Represents an error object.
@@ -52,14 +53,9 @@ export class Error {
 
   get message() {
     let message = this.translatedMessage;
-    if (this.options.count != undefined) {
-      for (const key of ["{{count}}", "%{count}"]) {
-        message = message.replace(key, this.options.count.toString());
-      }
-    }
-    if (message.includes("{attribute}")) {
-      for (const key of ["{{attribute}}", "%{attribute}"]) {
-        message = message.replace(key, this.options.attribute || "confirmation");
+    for (const [key, value] of Object.entries(this.options)) {
+      for (const placeholder of [`{{${key}}}`, `%{${key}}`]) {
+        message = message.replace(placeholder, value?.toString() || "");
       }
     }
     return message;

--- a/packages/accel-record-core/src/validation/errors.ts
+++ b/packages/accel-record-core/src/validation/errors.ts
@@ -6,19 +6,19 @@ const defaultMessages: Record<string, string | undefined> = {
   accepted: "must be accepted",
   invalid: "is invalid",
   inclusion: "is not included in the list",
-  tooShort: "is too short (minimum is %{count} characters)",
-  tooLong: "is too long (maximum is %{count} characters)",
+  tooShort: "is too short (minimum is {{count}} characters)",
+  tooLong: "is too long (maximum is {{count}} characters)",
   taken: "has already been taken",
-  confirmation: "doesn't match %{attribute}",
+  confirmation: "doesn't match {{attribute}}",
 
   notANumber: "is not a number",
   notAnInteger: "must be an integer",
-  equalTo: "must be equal to %{count}",
-  greaterThan: "must be greater than %{count}",
-  greaterThanOrEqualTo: "must be greater than or equal to %{count}",
-  lessThan: "must be less than %{count}",
-  lessThanOrEqualTo: "must be less than or equal to %{count}",
-  otherThan: "must be other than %{count}",
+  equalTo: "must be equal to {{count}}",
+  greaterThan: "must be greater than {{count}}",
+  greaterThanOrEqualTo: "must be greater than or equal to {{count}}",
+  lessThan: "must be less than {{count}}",
+  lessThanOrEqualTo: "must be less than or equal to {{count}}",
+  otherThan: "must be other than {{count}}",
   odd: "must be odd",
   even: "must be even",
 };
@@ -53,10 +53,14 @@ export class Error {
   get message() {
     let message = this.translatedMessage;
     if (this.options.count != undefined) {
-      message = message.replace("%{count}", this.options.count.toString());
+      for (const key of ["{{count}}", "%{count}"]) {
+        message = message.replace(key, this.options.count.toString());
+      }
     }
-    if (message.includes("%{attribute}")) {
-      message = message.replace("%{attribute}", this.options.attribute || "confirmation");
+    if (message.includes("{attribute}")) {
+      for (const key of ["{{attribute}}", "%{attribute}"]) {
+        message = message.replace(key, this.options.attribute || "confirmation");
+      }
     }
     return message;
   }

--- a/packages/accel-record-core/src/validation/validator/numericality.ts
+++ b/packages/accel-record-core/src/validation/validator/numericality.ts
@@ -1,17 +1,74 @@
 import { Model } from "../../index.js";
 import { DefualtOptions, Validator } from "./index.js";
 
+/**
+ * Options for numericality validation.
+ */
 export type NumericalityOptions = {
+  /**
+   * Validates that the value is of type Number.
+   *
+   * The message key is `notANumber`. The default message is `is not a number`.
+   */
   onlyNumeric?: boolean;
+  /**
+   * Validates that the value is an integer.
+   *
+   * The message key is `notAnInteger`. The default message is `must be an integer`.
+   */
   onlyInteger?: boolean;
+  /**
+   * Validates that the value is equal to the specified number.
+   *
+   * The message key is `equalTo`. The default message is `must be equal to {{count}}`.
+   */
   equalTo?: number;
+  /**
+   * Validates that the value is greater than the specified number.
+   *
+   * The message key is `greaterThan`. The default message is `must be greater than {{count}}`.
+   */
   greaterThan?: number;
+  /**
+   * Validates that the value is greater than or equal to the specified number.
+   *
+   * The message key is `greaterThanOrEqualTo`. The default message is `must be greater than or equal to {{count}}`.
+   */
   greaterThanOrEqualTo?: number;
+  /**
+   * Validates that the value is less than the specified number.
+   *
+   * The message key is `lessThan`. The default message is `must be less than {{count}}`.
+   */
   lessThan?: number;
+  /**
+   * Validates that the value is less than or equal to the specified number.
+   *
+   * The message key is `lessThanOrEqualTo`. The default message is `must be less than or equal to {{count}}`.
+   */
   lessThanOrEqualTo?: number;
+  /**
+   * Validates that the value is other than the specified number.
+   *
+   * The message key is `otherThan`. The default message is `must be other than {{count}}`.
+   */
   otherThan?: number;
+  /**
+   * Validates that the value is odd.
+   *
+   * The message key is `odd`. The default message is `must be odd`.
+   */
   odd?: boolean;
+  /**
+   * Validates that the value is even.
+   *
+   * The message key is `even`. The default message is `must be even`.
+   */
   even?: boolean;
+  /**
+   * Allows the value to be undefined.
+   * The default value is `false`.
+   */
   allowBlank?: boolean;
 } & DefualtOptions;
 
@@ -73,10 +130,7 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
   }
 
   private validateInteger(value: number) {
-    if (
-      this.options.onlyInteger === true &&
-      Number.isInteger(value) === false
-    ) {
+    if (this.options.onlyInteger === true && Number.isInteger(value) === false) {
       this.errors.add(this.attribute, this.options.message ?? "notAnInteger");
     }
   }
@@ -88,10 +142,7 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
   }
 
   private validateOtherThan(value: number) {
-    if (
-      this.options.otherThan != undefined &&
-      value === this.options.otherThan
-    ) {
+    if (this.options.otherThan != undefined && value === this.options.otherThan) {
       this.errors.add(this.attribute, this.options.message ?? "otherThan", {
         count: this.options.otherThan,
       });
@@ -107,25 +158,15 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
   }
 
   private validateLessThanOrEqualTo(value: number) {
-    if (
-      this.options.lessThanOrEqualTo != undefined &&
-      value > this.options.lessThanOrEqualTo
-    ) {
-      this.errors.add(
-        this.attribute,
-        this.options.message ?? "lessThanOrEqualTo",
-        {
-          count: this.options.lessThanOrEqualTo,
-        }
-      );
+    if (this.options.lessThanOrEqualTo != undefined && value > this.options.lessThanOrEqualTo) {
+      this.errors.add(this.attribute, this.options.message ?? "lessThanOrEqualTo", {
+        count: this.options.lessThanOrEqualTo,
+      });
     }
   }
 
   private validateGreaterThan(value: number) {
-    if (
-      this.options.greaterThan != undefined &&
-      value <= this.options.greaterThan
-    ) {
+    if (this.options.greaterThan != undefined && value <= this.options.greaterThan) {
       this.errors.add(this.attribute, this.options.message ?? "greaterThan", {
         count: this.options.greaterThan,
       });
@@ -137,13 +178,9 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
       this.options.greaterThanOrEqualTo != undefined &&
       value < this.options.greaterThanOrEqualTo
     ) {
-      this.errors.add(
-        this.attribute,
-        this.options.message ?? "greaterThanOrEqualTo",
-        {
-          count: this.options.greaterThanOrEqualTo,
-        }
-      );
+      this.errors.add(this.attribute, this.options.message ?? "greaterThanOrEqualTo", {
+        count: this.options.greaterThanOrEqualTo,
+      });
     }
   }
 }

--- a/packages/accel-record-core/src/validation/validator/numericality.ts
+++ b/packages/accel-record-core/src/validation/validator/numericality.ts
@@ -48,6 +48,12 @@ export type NumericalityOptions = {
    */
   lessThanOrEqualTo?: number;
   /**
+   * Validates that the value is between the specified numbers.
+   *
+   * The message key is `between`. The default message is `must be between {{min}} and {{max}}`.
+   */
+  between?: [number, number];
+  /**
    * Validates that the value is other than the specified number.
    *
    * The message key is `otherThan`. The default message is `must be other than {{count}}`.
@@ -98,6 +104,8 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
 
     this.validateLessThan(num);
     this.validateLessThanOrEqualTo(num);
+
+    this.validateBetween(num);
 
     this.validateOdd(num);
     this.validateEven(num);
@@ -181,6 +189,18 @@ export class NumericalityValidator<T extends Model> extends Validator<T> {
       this.errors.add(this.attribute, this.options.message ?? "greaterThanOrEqualTo", {
         count: this.options.greaterThanOrEqualTo,
       });
+    }
+  }
+
+  private validateBetween(num: number) {
+    if (this.options.between != undefined) {
+      const [min, max] = this.options.between;
+      if (num < min || max < num) {
+        this.errors.add(this.attribute, this.options.message ?? "between", {
+          min,
+          max,
+        });
+      }
     }
   }
 }

--- a/packages/accel-record-core/src/validation/validator/numericality.ts
+++ b/packages/accel-record-core/src/validation/validator/numericality.ts
@@ -1,0 +1,149 @@
+import { Model } from "../../index.js";
+import { DefualtOptions, Validator } from "./index.js";
+
+export type NumericalityOptions = {
+  onlyNumeric?: boolean;
+  onlyInteger?: boolean;
+  equalTo?: number;
+  greaterThan?: number;
+  greaterThanOrEqualTo?: number;
+  lessThan?: number;
+  lessThanOrEqualTo?: number;
+  otherThan?: number;
+  odd?: boolean;
+  even?: boolean;
+  allowBlank?: boolean;
+} & DefualtOptions;
+
+export class NumericalityValidator<T extends Model> extends Validator<T> {
+  constructor(
+    record: T,
+    private attribute: keyof T & string,
+    private options: NumericalityOptions
+  ) {
+    super(record);
+  }
+  validate() {
+    const value = this.record[this.attribute];
+    if (this.options.allowBlank && value == undefined) return;
+
+    this.validateNumeric(value);
+
+    const num = Number(value);
+    this.validateInteger(num);
+    this.validateFiniteNumber(num);
+
+    this.validateEqualTo(num);
+    this.validateOtherThan(num);
+
+    this.validateGreaterThan(num);
+    this.validateGreaterThanOrEqualTo(num);
+
+    this.validateLessThan(num);
+    this.validateLessThanOrEqualTo(num);
+
+    this.validateOdd(num);
+    this.validateEven(num);
+  }
+
+  private validateFiniteNumber(value: number) {
+    if (Number.isFinite(value) === false) {
+      this.errors.add(this.attribute, this.options.message ?? "notANumber");
+    }
+  }
+
+  private validateEven(value: number) {
+    if (this.options.even === true && value % 2 !== 0) {
+      this.errors.add(this.attribute, this.options.message ?? "even");
+    }
+  }
+
+  private validateOdd(value: number) {
+    if (this.options.odd === true && value % 2 === 0) {
+      this.errors.add(this.attribute, this.options.message ?? "odd");
+    }
+  }
+
+  private validateEqualTo(value: number) {
+    if (this.options.equalTo != undefined && value !== this.options.equalTo) {
+      this.errors.add(this.attribute, this.options.message ?? "equalTo", {
+        count: this.options.equalTo,
+      });
+    }
+  }
+
+  private validateInteger(value: number) {
+    if (
+      this.options.onlyInteger === true &&
+      Number.isInteger(value) === false
+    ) {
+      this.errors.add(this.attribute, this.options.message ?? "notAnInteger");
+    }
+  }
+
+  private validateNumeric(value: any) {
+    if (this.options.onlyNumeric === true && Number.isFinite(value) === false) {
+      this.errors.add(this.attribute, this.options.message ?? "notANumber");
+    }
+  }
+
+  private validateOtherThan(value: number) {
+    if (
+      this.options.otherThan != undefined &&
+      value === this.options.otherThan
+    ) {
+      this.errors.add(this.attribute, this.options.message ?? "otherThan", {
+        count: this.options.otherThan,
+      });
+    }
+  }
+
+  private validateLessThan(value: number) {
+    if (this.options.lessThan != undefined && value >= this.options.lessThan) {
+      this.errors.add(this.attribute, this.options.message ?? "lessThan", {
+        count: this.options.lessThan,
+      });
+    }
+  }
+
+  private validateLessThanOrEqualTo(value: number) {
+    if (
+      this.options.lessThanOrEqualTo != undefined &&
+      value > this.options.lessThanOrEqualTo
+    ) {
+      this.errors.add(
+        this.attribute,
+        this.options.message ?? "lessThanOrEqualTo",
+        {
+          count: this.options.lessThanOrEqualTo,
+        }
+      );
+    }
+  }
+
+  private validateGreaterThan(value: number) {
+    if (
+      this.options.greaterThan != undefined &&
+      value <= this.options.greaterThan
+    ) {
+      this.errors.add(this.attribute, this.options.message ?? "greaterThan", {
+        count: this.options.greaterThan,
+      });
+    }
+  }
+
+  private validateGreaterThanOrEqualTo(value: number) {
+    if (
+      this.options.greaterThanOrEqualTo != undefined &&
+      value < this.options.greaterThanOrEqualTo
+    ) {
+      this.errors.add(
+        this.attribute,
+        this.options.message ?? "greaterThanOrEqualTo",
+        {
+          count: this.options.greaterThanOrEqualTo,
+        }
+      );
+    }
+  }
+}

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -842,12 +842,7 @@ Vitestを使ったテストでは、以下のようなsetupファイルを用意
 ```ts
 // tests/vitest.setup.ts
 
-import {
-  DatabaseCleaner,
-  Migration,
-  initAccelRecord,
-  stopWorker,
-} from "accel-record";
+import { DatabaseCleaner, Migration, initAccelRecord, stopWorker } from "accel-record";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -1264,8 +1259,9 @@ i18next
 | uniqueness     | -          | 'taken'        | -      |
 | format         | -          | 'invalid'      | -      |
 | inclusion      | -          | 'inclusion'    | -      |
+| numericality   | 'equalTo'  | 'equalTo'      | count  |
 
-式展開が `count` になっているものは、エラーメッセージに `%{count}` を含むときにその部分がオプションで指定された値に置き換えられます。
+式展開が `count` になっているものは、エラーメッセージに `{{count}}` を含むときにその部分がオプションで指定された値に置き換えられます。
 
 ### Enumの翻訳
 

--- a/packages/accel-record/README.md
+++ b/packages/accel-record/README.md
@@ -841,12 +841,7 @@ In Vitest, you prepare a setup file like the following for testing.
 ```ts
 // tests/vitest.setup.ts
 
-import {
-  DatabaseCleaner,
-  Migration,
-  initAccelRecord,
-  stopWorker,
-} from "accel-record";
+import { DatabaseCleaner, Migration, initAccelRecord, stopWorker } from "accel-record";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -1254,17 +1249,18 @@ i18next
 
 The message keys corresponding to each validation are as follows:
 
-| Validation | Option    | Message Key | Interpolation |
-| ---------- | --------- | ----------- | ------------- |
-| acceptance | -         | 'accepted'  | -             |
-| presence   | -         | 'blank'     | -             |
-| length     | 'minimum' | 'tooShort'  | count         |
-| length     | 'maximum' | 'tooLong'   | count         |
-| uniqueness | -         | 'taken'     | -             |
-| format     | -         | 'invalid'   | -             |
-| inclusion  | -         | 'inclusion' | -             |
+| Validation   | Option    | Message Key | Interpolation |
+| ------------ | --------- | ----------- | ------------- |
+| acceptance   | -         | 'accepted'  | -             |
+| presence     | -         | 'blank'     | -             |
+| length       | 'minimum' | 'tooShort'  | count         |
+| length       | 'maximum' | 'tooLong'   | count         |
+| uniqueness   | -         | 'taken'     | -             |
+| format       | -         | 'invalid'   | -             |
+| inclusion    | -         | 'inclusion' | -             |
+| numericality | 'equalTo' | 'equalTo'   | count         |
 
-For those with interpolation set to `count`, that part will be replaced with the value specified in the option when the error message contains `%{count}`.
+For those with interpolation set to `count`, that part will be replaced with the value specified in the option when the error message contains `{{count}}`.
 
 ### Translation of Enums
 

--- a/tests/validation/validator/numericality.test.ts
+++ b/tests/validation/validator/numericality.test.ts
@@ -71,6 +71,15 @@ describe("error message", () => {
     expect(subject()).toBe("Count must be less than or equal to -1");
   });
 
+  test("numericality between", () => {
+    sample.validates("pattern", { numericality: { between: [120, 123] } });
+    expect(subject()).toBeUndefined();
+    sample.validates("key", { numericality: { between: [-15.5, -12.3] } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { between: [0.1, 0.5] } });
+    expect(subject()).toBe("Count must be between 0.1 and 0.5");
+  });
+
   test("numericality otherThan", () => {
     sample.validates("pattern", { numericality: { otherThan: 0 } });
     expect(subject()).toBeUndefined();

--- a/tests/validation/validator/numericality.test.ts
+++ b/tests/validation/validator/numericality.test.ts
@@ -1,0 +1,102 @@
+import { $ValidateSample } from "../../factories/validateSample";
+import { NewValidateSample } from "../../models";
+
+describe("error message", () => {
+  let sample: NewValidateSample;
+  beforeEach(() => {
+    sample = $ValidateSample.build({
+      count: 0,
+      size: "small",
+      pattern: "+123",
+      key: "-12.3",
+    });
+  });
+  const subject = () => sample.errors.fullMessages[0];
+
+  test("numericality", () => {
+    sample.validates("count", { numericality: {} });
+    expect(subject()).toBeUndefined();
+    sample.validates("size", { numericality: {} });
+    expect(subject()).toBe("Size is not a number");
+  });
+
+  test("numericality onlyNumeric", () => {
+    sample.validates("count", { numericality: { onlyNumeric: true } });
+    expect(subject()).toBeUndefined();
+    sample.validates("pattern", { numericality: { onlyNumeric: true } });
+    expect(subject()).toBe("Pattern is not a number");
+  });
+
+  test("numericality onlyInteger", () => {
+    sample.validates("pattern", { numericality: { onlyInteger: true } });
+    expect(subject()).toBeUndefined();
+    sample.validates("key", { numericality: { onlyInteger: true } });
+    expect(subject()).toBe("Key must be an integer");
+  });
+
+  test("numericality equalTo", () => {
+    sample.validates("pattern", { numericality: { equalTo: 123 } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { equalTo: 1 } });
+    expect(subject()).toBe("Count must be equal to 1");
+  });
+
+  test("numericality greaterThan", () => {
+    sample.validates("pattern", { numericality: { greaterThan: 122 } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { greaterThan: 0 } });
+    expect(subject()).toBe("Count must be greater than 0");
+  });
+
+  test("numericality greaterThanOrEqualTo", () => {
+    sample.validates("pattern", {
+      numericality: { greaterThanOrEqualTo: 123 },
+    });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { greaterThanOrEqualTo: 1 } });
+    expect(subject()).toBe("Count must be greater than or equal to 1");
+  });
+
+  test("numericality lessThan", () => {
+    sample.validates("pattern", { numericality: { lessThan: 124 } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { lessThan: 0 } });
+    expect(subject()).toBe("Count must be less than 0");
+  });
+
+  test("numericality lessThanOrEqualTo", () => {
+    sample.validates("pattern", { numericality: { lessThanOrEqualTo: 123 } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { lessThanOrEqualTo: -1 } });
+    expect(subject()).toBe("Count must be less than or equal to -1");
+  });
+
+  test("numericality otherThan", () => {
+    sample.validates("pattern", { numericality: { otherThan: 0 } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { otherThan: 0 } });
+    expect(subject()).toBe("Count must be other than 0");
+  });
+
+  test("numericality odd", () => {
+    sample.validates("pattern", { numericality: { odd: true } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { odd: true } });
+    expect(subject()).toBe("Count must be odd");
+  });
+
+  test("numericality even", () => {
+    sample.validates("count", { numericality: { even: true } });
+    expect(subject()).toBeUndefined();
+    sample.validates("pattern", { numericality: { even: true } });
+    expect(subject()).toBe("Pattern must be even");
+  });
+
+  test("numericality allowBlank", () => {
+    sample.count = undefined;
+    sample.validates("count", { numericality: { allowBlank: true } });
+    expect(subject()).toBeUndefined();
+    sample.validates("count", { numericality: { allowBlank: false } });
+    expect(subject()).toBe("Count is not a number");
+  });
+});


### PR DESCRIPTION
```ts
// src/models/todo.ts
import { ApplicationRecord } from "./applicationRecord.js";

export class TodoModel extends ApplicationRecord {
  override validateAttributes() {
    this.validates("priority", {
      numericality: { between: [1, 5], onlyInteger: true, allowBlank: true },
    });
  }
}
```