### PR TITLE
[accel-web] Pagination

### DIFF
--- a/examples/web_astro/src/core/i18n.ts
+++ b/examples/web_astro/src/core/i18n.ts
@@ -1,0 +1,50 @@
+import i18next from "i18next";
+
+export const initI18n = async () => {
+  // return;
+  await i18next.init({ lng: "ja", resources: { ja } });
+  // await i18next.changeLanguage("en");
+};
+
+const ja = {
+  translation: {
+    "accelrecord.attributes.Account.email": "メールアドレス",
+    "accelrecord.attributes.Account.password": "パスワード",
+    "accelrecord.attributes.Account.passwordConfirmation": "パスワード(確認用)",
+
+    "accelrecord.attributes.SignIn.email": "メールアドレス",
+    "accelrecord.attributes.SignIn.password": "パスワード",
+
+    "accelrecord.attributes.Todo.title": "タイトル",
+    "accelrecord.attributes.Todo.estimate": "見積もり",
+    "accelrecord.attributes.Todo.dueDate": "期日",
+    "accelrecord.attributes.Todo.status": "ステータス",
+    "accelrecord.attributes.Todo.available": "有効",
+    "accelrecord.attributes.Todo.description": "詳細",
+
+    "enums.Status": "ステータス",
+    "enums.Status.OPEN": "オープン",
+    "enums.Status.CLOSED": "クローズド",
+
+    "errors.messages.blank": "を入力してください",
+    "errors.messages.accepted": "をチェックしてください",
+    "errors.messages.invalid": "は不正です",
+    "errors.messages.inclusion": "はリストに含まれていません",
+    "errors.messages.tooShort": "は短すぎます(%{count}文字以上)",
+    "errors.messages.tooLong": "は長すぎます(%{count}文字以下)",
+    "errors.messages.taken": "は既に使用されています",
+    "errors.messages.confirmation": "と%{attribute}の入力が一致しません",
+
+    // pagination
+    "views.pagination.first": "&laquo; 最初",
+    "views.pagination.last": "最後 &raquo;",
+    "views.pagination.previous": "&lsaquo; 前",
+    "views.pagination.next": "次 &rsaquo;",
+    "views.pagination.truncate": "&hellip;",
+
+    "helpers.pageEntriesInfo.onePage.displayEntries_zero": "レコードが見つかりませんでした",
+    "helpers.pageEntriesInfo.onePage.displayEntries_other": "<b>全{{total}}</b>件表示中",
+    "helpers.pageEntriesInfo.morePages.displayEntries":
+      "<b>{{first}}-{{last}}</b>件 / {{total}}件中",
+  },
+};

--- a/examples/web_astro/src/middleware.ts
+++ b/examples/web_astro/src/middleware.ts
@@ -1,6 +1,8 @@
 import { defineMiddleware } from "astro:middleware";
 import { initDatabase } from "./core/database.js";
+import { initI18n } from "./core/i18n.js";
 
+await initI18n();
 await initDatabase();
 
 export const onRequest = defineMiddleware((_context, next) => {

--- a/examples/web_astro/src/pages/index.astro
+++ b/examples/web_astro/src/pages/index.astro
@@ -1,7 +1,50 @@
 ---
+import { paginate } from "accel-web";
+import { Account } from "src/models";
 import Layout from "../layouts/Layout.astro";
+
+const url = new URL(Astro.request.url);
+const searchParams = url.searchParams;
+const page = Number(searchParams.get("p")) || 1;
+
+const q = Account.all();
+
+const pager = paginate(q.order("id", "desc"), {
+  page,
+  per: 10,
+  window: 2,
+});
+const { LinkToNextPage, LinkToPrevPage, Nav, PageEntriesInfo } = pager;
 ---
 
-<Layout title="Index">
-  <main class="container" style="max-width: 700px; min-width: 550px;">Index Page</main>
+<Layout title="All Accounts">
+  <main class="container" style="max-width: 700px; min-width: 550px;">
+    <h1 class="text-center">All Accounts</h1>
+    <nav>
+      <ul class="pagination">
+        {page > 1 && <LinkToPrevPage />}
+        <LinkToNextPage />
+      </ul>
+    </nav>
+    <div class="d-flex flex-column gap-2 mb-3" style="padding: 20px">
+      <div class="d-flex gap-3">
+        <div>ID</div>
+        <div>Email</div>
+      </div>
+      {
+        pager.records.map((account) => (
+          <div class="d-flex gap-3">
+            <div>{account.id}</div>
+            <div>{account.email}</div>
+          </div>
+        ))
+      }
+    </div>
+    <div class="d-flex justify-content-center">
+      <Nav />
+    </div>
+    <div class="d-flex justify-content-center">
+      <PageEntriesInfo />
+    </div>
+  </main>
 </Layout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       }
     },
     "examples/web_astro": {
+      "name": "examples-astro",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.8.1",
@@ -535,7 +536,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
       "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
-      "devOptional": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -4484,7 +4484,6 @@
       "version": "23.11.5",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.11.5.tgz",
       "integrity": "sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -6926,8 +6925,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "devOptional": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regex": {
       "version": "4.3.3",
@@ -9026,7 +9024,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "accel-record": "^1.15.0",
-        "astro": "^4.0.0"
+        "astro": ">=4.0.0",
+        "i18next": ">=23.0.0"
       },
       "devDependencies": {}
     },

--- a/packages/accel-web/README.md
+++ b/packages/accel-web/README.md
@@ -1,3 +1,69 @@
 # Accel Web
 
 This is a library for integrating Astro and Accel Record.
+
+## Pagination
+
+`paginate` is a function that generates pagination components. It takes a query and options as arguments.
+
+```astro
+---
+import { paginate } from "accel-web";
+import { Account } from "src/models";
+
+const url = new URL(Astro.request.url);
+const page = Number(url.searchParams.get("p")) || 1;
+
+const { Nav, PageEntriesInfo } = paginate(Account.order("id", "desc"), { page, per: 10, window: 1 });
+---
+
+<!-- nav -->
+<Nav />
+
+<!-- info -->
+<PageEntriesInfo />
+```
+
+The above code will render a result like:
+
+```html
+<!-- nav -->
+<nav>
+  <ul class="pagination">
+    <li class="page-item first">
+      <a href="/?p=1" class="page-link">« First</a>
+    </li>
+    <li class="page-item prev">
+      <a rel="prev" href="/?p=2" class="page-link">‹ Prev</a>
+    </li>
+    <li class="page-item disabled gap">
+      <span class="page-link">…</span>
+    </li>
+    <li class="page-item page">
+      <a href="/?p=2" class="page-link"> 2 </a>
+    </li>
+    <li class="page-item page active">
+      <span class="page-link">3</span>
+    </li>
+    <li class="page-item page">
+      <a href="/?p=4" class="page-link"> 4 </a>
+    </li>
+    <li class="page-item disabled gap">
+      <span class="page-link">…</span>
+    </li>
+    <li class="page-item next">
+      <a rel="next" href="/?p=4" class="page-link">Next ›</a>
+    </li>
+    <li class="page-item last">
+      <a href="/?p=6" class="page-link">Last »</a>
+    </li>
+  </ul>
+</nav>
+
+<!-- info -->
+<div class="page-entries-info">Displaying <b>21 - 30</b> of <b>55</b> in total</div>
+```
+
+The following styles will be applied when Bootstrap 5 is used. You can override the styles by adding your own CSS.
+
+![Pagination UI with Bootstrap](https://github.com/user-attachments/assets/7c0dab8d-c22d-47ef-8e31-10eac12c8e06)

--- a/packages/accel-web/package.json
+++ b/packages/accel-web/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "accel-record": "^1.15.0",
-    "astro": "^4.0.0"
+    "astro": ">=4.0.0",
+    "i18next": ">=23.0.0"
   }
 }

--- a/packages/accel-web/src/index.ts
+++ b/packages/accel-web/src/index.ts
@@ -1,0 +1,1 @@
+export { paginate } from "./paginate/index.js";

--- a/packages/accel-web/src/paginate/common.ts
+++ b/packages/accel-web/src/paginate/common.ts
@@ -1,0 +1,7 @@
+import type { APIContext } from "astro";
+
+export const buildPageLink = (context: APIContext, p: number) => {
+  const url = new URL(context.url);
+  url.searchParams.set("p", String(p));
+  return url.toString();
+};

--- a/packages/accel-web/src/paginate/gap.astro
+++ b/packages/accel-web/src/paginate/gap.astro
@@ -1,0 +1,7 @@
+---
+import I18n from "i18next";
+---
+
+<li class="page-item disabled gap">
+  <span class="page-link" set:html={I18n.t("views.pagination.truncate", "&hellip;")} />
+</li>

--- a/packages/accel-web/src/paginate/gap.astro
+++ b/packages/accel-web/src/paginate/gap.astro
@@ -1,7 +1,5 @@
 ---
 import I18n from "i18next";
-
-I18n.isInitialized || (await I18n.init());
 ---
 
 <li class="page-item disabled gap">

--- a/packages/accel-web/src/paginate/gap.astro
+++ b/packages/accel-web/src/paginate/gap.astro
@@ -1,5 +1,7 @@
 ---
 import I18n from "i18next";
+
+I18n.isInitialized || (await I18n.init());
 ---
 
 <li class="page-item disabled gap">

--- a/packages/accel-web/src/paginate/index.ts
+++ b/packages/accel-web/src/paginate/index.ts
@@ -1,0 +1,39 @@
+import type { Relation } from "accel-record";
+import { createComponent } from "astro/runtime/server/astro-component.js";
+import LinkToNextPage from "./linkToNextPage.astro";
+import LinkToPrevPage from "./linkToPrevPage.astro";
+import Nav from "./nav.astro";
+import PageEntriesInfo from "./pageEntriesInfo.astro";
+
+export const paginate = <T>(
+  query: Relation<T, any>,
+  options: { page: number; per?: number; window?: number; count?: boolean }
+) => {
+  const page = options.page;
+  const per = options.per ?? 25;
+  const count = options.count ?? true;
+  const window = options.window ?? 4;
+  const offset = (page - 1) * per;
+  const total = count ? query.count() : 0;
+  const totalPages = Math.ceil(total / per);
+  return {
+    page,
+    per,
+    total,
+    totalPages,
+    records: query.offset(offset).limit(per),
+    PageEntriesInfo: ex(PageEntriesInfo, { offset, per, total }),
+    Nav: ex(Nav, { page, totalPages, window }),
+    LinkToPrevPage: ex(LinkToPrevPage, { page }),
+    LinkToNextPage: ex(LinkToNextPage, { page }),
+  };
+};
+
+export const ex = (base: any, defaults: any, removes: string[] = []): (() => any) => {
+  return createComponent((...args) => {
+    for (const remove of removes) {
+      delete args[1][remove];
+    }
+    return base(args[0], { ...defaults, ...args[1] }, args[2]);
+  }) as any;
+};

--- a/packages/accel-web/src/paginate/index.ts
+++ b/packages/accel-web/src/paginate/index.ts
@@ -5,10 +5,40 @@ import LinkToPrevPage from "./linkToPrevPage.astro";
 import Nav from "./nav.astro";
 import PageEntriesInfo from "./pageEntriesInfo.astro";
 
-export const paginate = <T>(
-  query: Relation<T, any>,
-  options: { page: number; per?: number; window?: number; count?: boolean }
-) => {
+export type Options = {
+  /**
+   * The current page number.
+   */
+  page: number;
+  /**
+   * The number of records per page.
+   * @default 25
+   */
+  per?: number;
+  /**
+   * The number of pages to display in the pagination window.
+   * @default 4
+   */
+  window?: number;
+  /**
+   * Whether to count the total number of records.
+   * @default true
+   */
+  count?: boolean;
+};
+
+/**
+ * Paginates a query result set based on the provided options.
+ *
+ * @example
+ * ```ts
+ * import { User } from "./models/index.js";
+ * import { paginate } from "accel-web";
+ *
+ * const { Nav, PageEntriesInfo } = paginate(User.order('id', 'desc'), { page: 1, per: 10 });
+ * ```
+ */
+export const paginate = <T>(query: Relation<T, any>, options: Options) => {
   const page = options.page;
   const per = options.per ?? 25;
   const count = options.count ?? true;
@@ -17,14 +47,41 @@ export const paginate = <T>(
   const total = count ? query.count() : 0;
   const totalPages = Math.ceil(total / per);
   return {
+    /**
+     * The current page number.
+     */
     page,
+    /**
+     * The number of records per page.
+     */
     per,
+    /**
+     * The total number of records.
+     */
     total,
+    /**
+     * The total number of pages.
+     */
     totalPages,
+    /**
+     * The records for the current page.
+     */
     records: query.offset(offset).limit(per),
+    /**
+     * Information component about the page entries.
+     */
     PageEntriesInfo: ex(PageEntriesInfo, { offset, per, total }),
+    /**
+     * Navigation component for the pagination.
+     */
     Nav: ex(Nav, { page, totalPages, window }),
+    /**
+     * Link component to the previous page.
+     */
     LinkToPrevPage: ex(LinkToPrevPage, { page }),
+    /**
+     * Link component to the next page.
+     */
     LinkToNextPage: ex(LinkToNextPage, { page }),
   };
 };

--- a/packages/accel-web/src/paginate/linkToNextPage.astro
+++ b/packages/accel-web/src/paginate/linkToNextPage.astro
@@ -1,0 +1,17 @@
+---
+import I18n from "i18next";
+import { buildPageLink } from "./common";
+interface Props {
+  page: number;
+}
+const { page } = Astro.props;
+---
+
+<li class="page-item next">
+  <a
+    rel="next"
+    href={buildPageLink(Astro, page + 1)}
+    class="page-link"
+    set:html={I18n.t("views.pagination.next", "Next &rsaquo;")}
+  />
+</li>

--- a/packages/accel-web/src/paginate/linkToNextPage.astro
+++ b/packages/accel-web/src/paginate/linkToNextPage.astro
@@ -1,6 +1,9 @@
 ---
 import I18n from "i18next";
 import { buildPageLink } from "./common";
+
+I18n.isInitialized || (await I18n.init());
+
 interface Props {
   page: number;
 }

--- a/packages/accel-web/src/paginate/linkToNextPage.astro
+++ b/packages/accel-web/src/paginate/linkToNextPage.astro
@@ -2,8 +2,6 @@
 import I18n from "i18next";
 import { buildPageLink } from "./common";
 
-I18n.isInitialized || (await I18n.init());
-
 interface Props {
   page: number;
 }

--- a/packages/accel-web/src/paginate/linkToPrevPage.astro
+++ b/packages/accel-web/src/paginate/linkToPrevPage.astro
@@ -1,0 +1,17 @@
+---
+import I18n from "i18next";
+import { buildPageLink } from "./common";
+interface Props {
+  page: number;
+}
+const { page } = Astro.props;
+---
+
+<li class="page-item prev">
+  <a
+    rel="prev"
+    href={buildPageLink(Astro, page - 1)}
+    class="page-link"
+    set:html={I18n.t("views.pagination.previous", "&lsaquo; Prev")}
+  />
+</li>

--- a/packages/accel-web/src/paginate/linkToPrevPage.astro
+++ b/packages/accel-web/src/paginate/linkToPrevPage.astro
@@ -1,6 +1,9 @@
 ---
 import I18n from "i18next";
 import { buildPageLink } from "./common";
+
+I18n.isInitialized || (await I18n.init());
+
 interface Props {
   page: number;
 }

--- a/packages/accel-web/src/paginate/linkToPrevPage.astro
+++ b/packages/accel-web/src/paginate/linkToPrevPage.astro
@@ -2,8 +2,6 @@
 import I18n from "i18next";
 import { buildPageLink } from "./common";
 
-I18n.isInitialized || (await I18n.init());
-
 interface Props {
   page: number;
 }

--- a/packages/accel-web/src/paginate/nav.astro
+++ b/packages/accel-web/src/paginate/nav.astro
@@ -1,0 +1,44 @@
+---
+import I18n from "i18next";
+import { buildPageLink } from "./common";
+import Gap from "./gap.astro";
+import LinkToNextPage from "./linkToNextPage.astro";
+import LinkToPrevPage from "./linkToPrevPage.astro";
+import PageLink from "./pageLink.astro";
+
+interface Props {
+  page: number;
+  totalPages: number;
+  window: number;
+}
+const { page, totalPages, window } = Astro.props;
+const min = page - window;
+const max = page + window;
+const pages = Array.from({ length: max - min + 1 }, (_, i) => min + i).filter(
+  (i) => 0 < i && i <= totalPages
+);
+---
+
+<nav>
+  <ul class="pagination">
+    <li class="page-item first">
+      <a
+        href={buildPageLink(Astro, 1)}
+        class="page-link"
+        set:html={I18n.t("views.pagination.first", "&laquo; First")}
+      />
+    </li>
+    {page > 1 && <LinkToPrevPage {page} />}
+    {pages[0] !== 1 && <Gap />}
+    {pages.map((i) => <PageLink i={i} {page} />)}
+    {pages[pages.length - 1] !== totalPages && <Gap />}
+    {page < totalPages && <LinkToNextPage {page} />}
+    <li class="page-item last">
+      <a
+        href={buildPageLink(Astro, totalPages)}
+        class="page-link"
+        set:html={I18n.t("views.pagination.last", "Last &raquo;")}
+      />
+    </li>
+  </ul>
+</nav>

--- a/packages/accel-web/src/paginate/nav.astro
+++ b/packages/accel-web/src/paginate/nav.astro
@@ -6,6 +6,8 @@ import LinkToNextPage from "./linkToNextPage.astro";
 import LinkToPrevPage from "./linkToPrevPage.astro";
 import PageLink from "./pageLink.astro";
 
+I18n.isInitialized || (await I18n.init());
+
 interface Props {
   page: number;
   totalPages: number;

--- a/packages/accel-web/src/paginate/nav.astro
+++ b/packages/accel-web/src/paginate/nav.astro
@@ -6,8 +6,6 @@ import LinkToNextPage from "./linkToNextPage.astro";
 import LinkToPrevPage from "./linkToPrevPage.astro";
 import PageLink from "./pageLink.astro";
 
-I18n.isInitialized || (await I18n.init());
-
 interface Props {
   page: number;
   totalPages: number;

--- a/packages/accel-web/src/paginate/pageEntriesInfo.astro
+++ b/packages/accel-web/src/paginate/pageEntriesInfo.astro
@@ -1,5 +1,8 @@
 ---
 import I18n from "i18next";
+
+I18n.isInitialized || (await I18n.init());
+
 interface Props {
   offset: number;
   per: number;
@@ -26,14 +29,10 @@ const defaultValue = () => {
 
 <div
   class="page-entries-info"
-  set:html={I18n.t(
-    `helpers.pageEntriesInfo.${key}.displayEntries`,
-    defaultValue(),
-    {
-      first,
-      last,
-      total,
-      count: total,
-    }
-  )}
+  set:html={I18n.t(`helpers.pageEntriesInfo.${key}.displayEntries`, defaultValue(), {
+    first,
+    last,
+    total,
+    count: total,
+  })}
 />

--- a/packages/accel-web/src/paginate/pageEntriesInfo.astro
+++ b/packages/accel-web/src/paginate/pageEntriesInfo.astro
@@ -1,0 +1,39 @@
+---
+import I18n from "i18next";
+interface Props {
+  offset: number;
+  per: number;
+  total: number;
+}
+const { offset, per, total } = Astro.props;
+const first = offset + 1;
+const last = Math.min(first + per - 1, total);
+const key = total <= per ? "onePage" : "morePages";
+const defaultValue = () => {
+  if (key == "morePages") {
+    return "Displaying <b>{{first}}&nbsp;-&nbsp;{{last}}</b> of <b>{{total}}</b> in total";
+  }
+  switch (total) {
+    case 0:
+      return "No entries found";
+    case 1:
+      return "Displaying <b>{{total}}</b> entry";
+    default:
+      return "Displaying <b>all {{total}}</b> entries";
+  }
+};
+---
+
+<div
+  class="page-entries-info"
+  set:html={I18n.t(
+    `helpers.pageEntriesInfo.${key}.displayEntries`,
+    defaultValue(),
+    {
+      first,
+      last,
+      total,
+      count: total,
+    }
+  )}
+/>

--- a/packages/accel-web/src/paginate/pageEntriesInfo.astro
+++ b/packages/accel-web/src/paginate/pageEntriesInfo.astro
@@ -1,8 +1,6 @@
 ---
 import I18n from "i18next";
 
-I18n.isInitialized || (await I18n.init());
-
 interface Props {
   offset: number;
   per: number;

--- a/packages/accel-web/src/paginate/pageLink.astro
+++ b/packages/accel-web/src/paginate/pageLink.astro
@@ -1,0 +1,20 @@
+---
+import { buildPageLink } from "./common";
+interface Props {
+  i: number;
+  page: number;
+}
+const { i, page } = Astro.props;
+---
+
+<li class={`page-item page ${i === page ? "active" : ""}`}>
+  {
+    i === page ? (
+      <span class="page-link">{i}</span>
+    ) : (
+      <a href={buildPageLink(Astro, i)} class="page-link">
+        {i}
+      </a>
+    )
+  }
+</li>


### PR DESCRIPTION
`paginate` is a function that generates pagination components. It takes a query and options as arguments.

```astro
---
import { paginate } from "accel-web";
import { Account } from "src/models";

const url = new URL(Astro.request.url);
const page = Number(url.searchParams.get("p")) || 1;

const { Nav, PageEntriesInfo } = paginate(Account.order("id", "desc"), { page, per: 10, window: 1 });
---

<!-- nav -->
<Nav />

<!-- info -->
<PageEntriesInfo />
```

The above code will render a result like:

```html
<!-- nav -->
<nav>
  <ul class="pagination">
    <li class="page-item first">
      <a href="/?p=1" class="page-link">« First</a>
    </li>
    <li class="page-item prev">
      <a rel="prev" href="/?p=2" class="page-link">‹ Prev</a>
    </li>
    <li class="page-item disabled gap">
      <span class="page-link">…</span>
    </li>
    <li class="page-item page">
      <a href="/?p=2" class="page-link"> 2 </a>
    </li>
    <li class="page-item page active">
      <span class="page-link">3</span>
    </li>
    <li class="page-item page">
      <a href="/?p=4" class="page-link"> 4 </a>
    </li>
    <li class="page-item disabled gap">
      <span class="page-link">…</span>
    </li>
    <li class="page-item next">
      <a rel="next" href="/?p=4" class="page-link">Next ›</a>
    </li>
    <li class="page-item last">
      <a href="/?p=6" class="page-link">Last »</a>
    </li>
  </ul>
</nav>

<!-- info -->
<div class="page-entries-info">Displaying <b>21 - 30</b> of <b>55</b> in total</div>
```

The following styles will be applied when Bootstrap 5 is used. You can override the styles by adding your own CSS.

![Pagination UI with Bootstrap](https://github.com/user-attachments/assets/7c0dab8d-c22d-47ef-8e31-10eac12c8e06)