### PR TITLE
[accel-web] Improvement of RequestParameters

### DIFF
--- a/examples/web_astro/src/pages/todos/index.astro
+++ b/examples/web_astro/src/pages/todos/index.astro
@@ -3,8 +3,8 @@ import { paginate, RequestParameters } from "accel-web";
 import { Todo } from "src/models";
 import Layout from "../../layouts/Layout.astro";
 
-const params = (await RequestParameters.from(Astro.request)).permit("p");
-const page = Number(params.p) || 1;
+const params = await RequestParameters.from(Astro.request);
+const page = Number(params["p"]) || 1;
 
 const { Nav, PageEntriesInfo, records } = paginate(Todo.order("id", "desc"), { page });
 ---

--- a/packages/accel-web/src/index.ts
+++ b/packages/accel-web/src/index.ts
@@ -1,3 +1,3 @@
 export { formFor } from "./form/index.js";
 export { paginate } from "./paginate/index.js";
-export { RequestParameters, ParameterMissing } from "./parameters.js";
+export { RequestParameters } from "./parameters.js";

--- a/packages/accel-web/src/parameters.ts
+++ b/packages/accel-web/src/parameters.ts
@@ -4,8 +4,6 @@ import z from "zod";
 
 type JsonObject = ReturnType<typeof parseFormData>;
 
-export class ParameterMissing extends Error {}
-
 /**
  * Class representing request parameters.
  */
@@ -62,14 +60,13 @@ export class RequestParameters {
    * Requires a specific key to be present in the parameters.
    * @param key - The key to require.
    * @returns A new instance of RequestParameters containing the required key's value.
-   * @throws ParameterMissing if the key is missing or its value is empty.
    */
   require(key: string): RequestParameters {
-    const value = this.data[key];
-    if (typeof value !== "object") {
-      throw new ParameterMissing(`param is missing or the value is empty: ${key}`);
-    }
-    return new RequestParameters(value as JsonObject);
+    // Ensure the key exists
+    z.any()
+      .refine((v) => key in v, { message: "Required", path: [key] })
+      .parse(this.data);
+    return new RequestParameters(this.data[key] as any);
   }
   /**
    * Converts the parameters to a JSON object.

--- a/packages/accel-web/src/parameters.ts
+++ b/packages/accel-web/src/parameters.ts
@@ -10,11 +10,16 @@ export class ParameterMissing extends Error {}
  * Class representing request parameters.
  */
 export class RequestParameters {
+  readonly [key: string]: any;
   /**
    * Creates an instance of RequestParameters.
    * @param data - The JSON object containing the request data.
    */
-  constructor(protected data: JsonObject) {}
+  constructor(protected data: JsonObject) {
+    Object.entries(data).forEach(([key, value]) => {
+      (this as any)[key] ??= value;
+    });
+  }
 
   /**
    * Creates an instance of RequestParameters from a Request object.

--- a/packages/accel-web/tests/parameters.test-d.ts
+++ b/packages/accel-web/tests/parameters.test-d.ts
@@ -22,4 +22,5 @@ test("RequestParameters", async () => {
       tags: string[];
     }>();
   }
+  expectTypeOf(params["page"]).toEqualTypeOf<any>();
 });

--- a/packages/accel-web/tests/parameters.test.ts
+++ b/packages/accel-web/tests/parameters.test.ts
@@ -31,6 +31,17 @@ test("RequestParameters", async () => {
 
   expect(() => params.require("foo")).toThrowError(ParameterMissing);
 
+  expect(params["page"]).toEqual("1");
+  expect(params["tags"]).toEqual(["good", "human"]);
+  expect(params["account"]).toEqual({ name: "John", age: 30 });
+  expect(params["foo"]).toBeUndefined();
+});
+
+test("RequestParameters errors", async () => {});
+
+test("RequestParameters toHash()", async () => {
+  const params = await buildParams();
+
   expect(params.toHash()).toEqual({
     account: {
       age: 30,
@@ -39,11 +50,6 @@ test("RequestParameters", async () => {
     page: "1",
     tags: ["good", "human"],
   });
-
-  expect(params["page"]).toEqual("1");
-  expect(params["tags"]).toEqual(["good", "human"]);
-  expect(params["account"]).toEqual({ name: "John", age: 30 });
-  expect(params["foo"]).toBeUndefined();
 });
 
 test("RequestParameters parseWith()", async () => {

--- a/packages/accel-web/tests/parameters.test.ts
+++ b/packages/accel-web/tests/parameters.test.ts
@@ -1,4 +1,5 @@
-import { ParameterMissing, RequestParameters } from "src/parameters";
+import { ZodError } from "astro/zod";
+import { RequestParameters } from "src/parameters";
 import z from "zod";
 
 const buildParams = async () => {
@@ -29,15 +30,11 @@ test("RequestParameters", async () => {
   const account = params.require("account").permit("name", "age");
   expect(account).toEqual({ name: "John", age: 30 });
 
-  expect(() => params.require("foo")).toThrowError(ParameterMissing);
-
   expect(params["page"]).toEqual("1");
   expect(params["tags"]).toEqual(["good", "human"]);
   expect(params["account"]).toEqual({ name: "John", age: 30 });
   expect(params["foo"]).toBeUndefined();
 });
-
-test("RequestParameters errors", async () => {});
 
 test("RequestParameters toHash()", async () => {
   const params = await buildParams();
@@ -93,4 +90,15 @@ test("RequestParameters safeParseWith()", async () => {
     expect(result.success).toBe(true);
     expect(result.data).toEqual({ priority: undefined });
   }
+});
+
+test("RequestParameters errors", async () => {
+  const params = await buildParams();
+
+  expect(() => params.require("foo")).toThrowError(ZodError);
+  expect(() => params.require("page")).not.toThrowError();
+
+  expect(() => {
+    params.parseWith(z.object({ foo: z.string() }));
+  }).toThrowError(ZodError);
 });

--- a/packages/accel-web/tests/parameters.test.ts
+++ b/packages/accel-web/tests/parameters.test.ts
@@ -39,6 +39,11 @@ test("RequestParameters", async () => {
     page: "1",
     tags: ["good", "human"],
   });
+
+  expect(params["page"]).toEqual("1");
+  expect(params["tags"]).toEqual(["good", "human"]);
+  expect(params["account"]).toEqual({ name: "John", age: 30 });
+  expect(params["foo"]).toBeUndefined();
 });
 
 test("RequestParameters parseWith()", async () => {


### PR DESCRIPTION
add dictionary access interface to RequestParameters

```ts
const params = await RequestParameters.from(Astro.request);
const page = Number(params["p"]) || 1;
```

use ZodError in Parameters#require()

```ts
expect(() => params.require("foo")).toThrowError(ZodError);

expect(() => {
  params.parseWith(z.object({ foo: z.string() }));
}).toThrowError(ZodError);
```

