### PR TITLE
[accel-web] Use Astro.params with RequestParameters

### DIFF
--- a/examples/web_astro/src/middleware.ts
+++ b/examples/web_astro/src/middleware.ts
@@ -7,9 +7,10 @@ import { RequestParameters } from "accel-web";
 await initI18n();
 await initDatabase();
 
-export const onRequest = defineMiddleware(async ({ locals, cookies, request, redirect }, next) => {
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { locals, cookies, request, redirect, params } = context;
   locals.session = getSession(cookies);
-  locals.params = await RequestParameters.from(request);
+  locals.params = await RequestParameters.from(request, params);
 
   const path = new URL(request.url).pathname;
   if (!locals.session.account && !path.startsWith("/sign")) {

--- a/examples/web_astro/src/pages/signup.astro
+++ b/examples/web_astro/src/pages/signup.astro
@@ -8,7 +8,7 @@ import { z } from "astro/zod";
 const account = Account.build({});
 
 if (Astro.request.method === "POST") {
-  const params = await RequestParameters.from(Astro.request);
+  const params = await RequestParameters.from(Astro.request, Astro.params);
   // Using zod, you can validate request parameters and extract them with type information
   const accountParams = params.require("account").parseWith(
     z.object({

--- a/packages/accel-web/README.md
+++ b/packages/accel-web/README.md
@@ -87,7 +87,7 @@ import { z } from "astro/zod";
 const account = Account.build({});
 
 if (Astro.request.method === "POST") {
-  const params = await RequestParameters.from(Astro.request);
+  const params = await RequestParameters.from(Astro.request, Astro.params);
   // Using zod, you can validate request parameters and extract them with type information
   const accountParams = params.require("account").parseWith(
     z.object({
@@ -179,7 +179,7 @@ if (session.account) {
 let message = '';
 
 if (Astro.request.method === "POST") {
-  const params = await RequestParameters.from(Astro.request);
+  const params = await RequestParameters.from(Astro.request, Astro.params);
   // Account model is assumed to have password authentication implemented.
   // https://github.com/koyopro/accella/tree/main/packages/accel-record#password-authentication
   const account = Account.findBy({ email: params['email'] });

--- a/packages/accel-web/tests/parameters.test.ts
+++ b/packages/accel-web/tests/parameters.test.ts
@@ -13,17 +13,20 @@ const buildParams = async () => {
     method: "POST",
     body: data,
   });
-  const params = await RequestParameters.from(request);
+  const params = await RequestParameters.from(request, {
+    id: "2",
+  });
   return params;
 };
 
 test("RequestParameters", async () => {
   const params = await buildParams();
 
-  expect(params.permit("page", "tags", "priority", "foo")).toEqual({
+  expect(params.permit("page", "tags", "priority", "id", "foo")).toEqual({
     page: "1",
     tags: ["good", "human"],
     priority: undefined,
+    id: "2",
     foo: undefined,
   });
 
@@ -44,6 +47,7 @@ test("RequestParameters toHash()", async () => {
       age: 30,
       name: "John",
     },
+    id: "2",
     page: "1",
     tags: ["good", "human"],
   });


### PR DESCRIPTION
Made Astro.params available to be used as the second argument of RequestParameters

```diff
-  const params = await RequestParameters.from(Astro.request);
+  const params = await RequestParameters.from(Astro.request, Astro.params);
```