### PR TITLE
[accel-record-core] improve type of Search

### DIFF
--- a/packages/accel-record-core/src/model/search.ts
+++ b/packages/accel-record-core/src/model/search.ts
@@ -78,7 +78,7 @@ export class Searchable {
    * ```
    */
   static search<T extends typeof Model>(this: T, params: Record<string, any> | undefined) {
-    return new Search(this, params);
+    return new Search<InstanceType<T>>(this, params);
   }
 
   /**

--- a/packages/accel-record-core/src/relation/search.ts
+++ b/packages/accel-record-core/src/relation/search.ts
@@ -79,6 +79,6 @@ export class Searchable {
    * ```
    */
   search<T, M extends ModelMeta>(this: Relation<T, M>, params: Record<string, any> | undefined) {
-    return new Search(this.model, params, this);
+    return new Search<T>(this.model, params, this);
   }
 }

--- a/packages/accel-record-core/src/search/index.ts
+++ b/packages/accel-record-core/src/search/index.ts
@@ -1,10 +1,10 @@
 import { AttributeNotFound } from "../errors.js";
-import type { Model } from "../index.js";
+import type { Meta, Model } from "../index.js";
 import type { Relation } from "../relation/index.js";
 import { isBlank } from "../validation/validator/presence.js";
 import { RelationUpdater } from "./relation.js";
 
-export class Search {
+export class Search<T> {
   readonly params: Record<string, any>;
   readonly [key: string]: any;
 
@@ -29,7 +29,7 @@ export class Search {
   /**
    * Retrieves the search result based on the specified parameters.
    */
-  result() {
+  result(): Relation<T, Meta<T>> {
     let relation = this.relation ?? this.model.all();
     for (const [key, value] of Object.entries(this.params)) {
       try {
@@ -40,6 +40,6 @@ export class Search {
         } else throw e;
       }
     }
-    return relation;
+    return relation as Relation<T, Meta<T>>;
   }
 }

--- a/packages/accel-web/src/searchFormFor.ts
+++ b/packages/accel-web/src/searchFormFor.ts
@@ -21,6 +21,6 @@ import { formFor } from "./form/index.js";
  * </Form>
  * ```
  */
-export const searchFormFor = (s: Search) => {
+export const searchFormFor = (s: Search<any>) => {
   return formFor(s, { namespace: "q" });
 };

--- a/tests/models/model/search.test-d.ts
+++ b/tests/models/model/search.test-d.ts
@@ -1,0 +1,6 @@
+import { User } from "..";
+
+test(".search()", () => {
+  expectTypeOf(User.search({}).result()).toEqualTypeOf(User.all());
+  expectTypeOf(User.all().search({}).result()).toEqualTypeOf(User.all());
+});


### PR DESCRIPTION
Modified `Search#result()` to return a Relation that includes the specific instance type.

```ts
test(".search()", () => {
  expectTypeOf(User.search({}).result()).toEqualTypeOf(User.all());
  expectTypeOf(User.all().search({}).result()).toEqualTypeOf(User.all());
});
```