### PR TITLE
[accel-web] options for searchFormFor()

### DIFF
--- a/examples/web_astro/src/middleware.ts
+++ b/examples/web_astro/src/middleware.ts
@@ -14,9 +14,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const path = new URL(request.url).pathname;
   if (!locals.session.account && !path.startsWith("/sign")) {
-    redirect("/signin");
-    return;
+    return redirect("/signin");
   }
 
-  next();
+  return next();
 });

--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -18,6 +18,11 @@ import label from "./label.astro";
 import select from "./select.astro";
 import textarea from "./textarea.astro";
 
+export type FormForOptions = {
+  /** Prefix of form field */
+  namespace?: string;
+};
+
 /**
  * Generates a set of form components for a given resource.
  *
@@ -40,7 +45,7 @@ import textarea from "./textarea.astro";
  * - `Textarea`: A textarea input field component.
  * - `Submit`: A submit button component.
  */
-export const formFor = (resource: any, options?: { namespace?: string }) => {
+export const formFor = (resource: any, options?: FormForOptions) => {
   const namespace = options?.namespace || "";
   const prefix = namespace
     ? `${namespace}.`

--- a/packages/accel-web/src/searchFormFor.ts
+++ b/packages/accel-web/src/searchFormFor.ts
@@ -1,5 +1,5 @@
 import { Search } from "accel-record/search";
-import { formFor } from "./form/index.js";
+import { formFor, FormForOptions } from "./form/index.js";
 
 /**
  * Generates a search form for the given search object.
@@ -21,6 +21,6 @@ import { formFor } from "./form/index.js";
  * </Form>
  * ```
  */
-export const searchFormFor = (s: Search<any>) => {
-  return formFor(s, { namespace: "q" });
+export const searchFormFor = (s: Search<any>, options: FormForOptions) => {
+  return formFor(s, { namespace: "q", ...options });
 };

--- a/tests/web/searchFormFor.test.ts
+++ b/tests/web/searchFormFor.test.ts
@@ -1,0 +1,10 @@
+import { searchFormFor } from "accel-web";
+import { User } from "../models";
+
+test("searchFormFor", async () => {
+  const search = User.search({});
+  const { Form, TextField, Submit } = searchFormFor(search, { namespace: "query" });
+  expect(Form).toBeDefined();
+  expect(TextField).toBeDefined();
+  expect(Submit).toBeDefined();
+});


### PR DESCRIPTION
`searchFormFor()` can now accept options.
```ts
const { Form, TextField, Submit } = searchFormFor(search, { namespace: "query" });
```