### PR TITLE
[accel-web] use FormModel namespace in formFor

### DIFF
--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -49,7 +49,7 @@ export const formFor = (resource: any, options?: FormForOptions) => {
   const namespace = options?.namespace || "";
   const prefix = namespace
     ? `${namespace}.`
-    : resource instanceof Model
+    : resource.class?.()?.name
       ? `${toCamelCase(resource.class().name)}.`
       : "";
   return {

--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -46,12 +46,7 @@ export type FormForOptions = {
  * - `Submit`: A submit button component.
  */
 export const formFor = (resource: any, options?: FormForOptions) => {
-  const namespace = options?.namespace || "";
-  const prefix = namespace
-    ? `${namespace}.`
-    : resource.class?.()?.name
-      ? `${toCamelCase(resource.class().name)}.`
-      : "";
+  const prefix = getPrefix(resource, options);
   return {
     Form: form as (props: astroHTML.JSX.FormHTMLAttributes) => any,
 
@@ -79,6 +74,13 @@ export const formFor = (resource: any, options?: FormForOptions) => {
 
     Submit: extendCommponent<"button", {}>(button, () => ({ type: "submit" })),
   };
+};
+
+const getPrefix = (resource: any, options?: FormForOptions) => {
+  if (options?.namespace) return options.namespace;
+  const name = resource.class?.()?.name;
+  if (name) return `${toCamelCase(name)}.`;
+  return "";
 };
 
 export const extendCommponent = <L extends keyof astroHTML.JSX.DefinedIntrinsicElements, P>(

--- a/packages/accel-web/tests/MyForm.astro
+++ b/packages/accel-web/tests/MyForm.astro
@@ -1,0 +1,13 @@
+---
+import { FormModel } from "accel-record";
+import { attributes } from "accel-record/attributes";
+import { formFor } from "accel-web";
+
+class SampleForm extends FormModel {
+  count = attributes.integer(0);
+}
+const form = SampleForm.build({});
+const { Label } = formFor(form);
+---
+
+<Label for="count" />

--- a/packages/accel-web/tests/formFor.test.ts
+++ b/packages/accel-web/tests/formFor.test.ts
@@ -1,0 +1,9 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import MyForm from "./MyForm.astro";
+
+test("formFor() with FormModel", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(MyForm);
+
+  expect(result).toContain('htmlFor="sampleForm.count"');
+});


### PR DESCRIPTION
When using formFor with an instance of a class that inherits from FormModel, the class name is now included in the prefix of the name.

```astro
---
import { FormModel } from "accel-record";
import { attributes } from "accel-record/attributes";
import { formFor } from "accel-web";

class SampleForm extends FormModel {
  count = attributes.integer(0);
}
const form = SampleForm.build({});
const { Label } = formFor(form);
---

<Label for="count" />
```

```html
<label htmlFor="sampleForm.count"> Count </label>
```