### PR TITLE
[accel-web] fix namespace bug in formFor()

### DIFF
--- a/.changeset/cyan-apricots-cry.md
+++ b/.changeset/cyan-apricots-cry.md
@@ -1,0 +1,5 @@
+---
+"accel-web": patch
+---
+
+Fixed the issue where the namespace passed to formFor() was not being reflected correctly.

--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -77,10 +77,9 @@ export const formFor = (resource: any, options?: FormForOptions) => {
 };
 
 const getPrefix = (resource: any, options?: FormForOptions) => {
-  if (options?.namespace) return options.namespace;
   const name = resource.class?.()?.name;
-  if (name) return `${toCamelCase(name)}.`;
-  return "";
+  const namespace = options?.namespace || (name ? toCamelCase(name) : undefined);
+  return namespace ? `${namespace}.` : "";
 };
 
 export const extendCommponent = <L extends keyof astroHTML.JSX.DefinedIntrinsicElements, P>(

--- a/packages/accel-web/tests/MyFormWithNamespace.astro
+++ b/packages/accel-web/tests/MyFormWithNamespace.astro
@@ -1,0 +1,13 @@
+---
+import { FormModel } from "accel-record";
+import { attributes } from "accel-record/attributes";
+import { formFor } from "accel-web";
+
+class SampleForm extends FormModel {
+  count = attributes.integer(0);
+}
+const form = SampleForm.build({});
+const { Label } = formFor(form, { namespace: "q" });
+---
+
+<Label for="count" />

--- a/packages/accel-web/tests/formFor.test.ts
+++ b/packages/accel-web/tests/formFor.test.ts
@@ -1,9 +1,17 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import MyForm from "./MyForm.astro";
+import MyFormWithNamespace from "./MyFormWithNamespace.astro";
 
 test("formFor() with FormModel", async () => {
   const container = await AstroContainer.create();
   const result = await container.renderToString(MyForm);
 
   expect(result).toContain('htmlFor="sampleForm.count"');
+});
+
+test("formFor() with namespace", async () => {
+  const container = await AstroContainer.create();
+  const result = await container.renderToString(MyFormWithNamespace);
+
+  expect(result).toContain('htmlFor="q.count"');
 });


### PR DESCRIPTION
Fixed the issue where the prefix did not include `.` when an explicit namespace was specified in formFor().