### PR TITLE
[accel-record] Add an option to use worker threads for synchronous processing

### DIFF
--- a/.changeset/rare-plums-allow.md
+++ b/.changeset/rare-plums-allow.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": minor
+"accel-record": minor
+---
+
+Added the sync-actions package and implemented synchronous query execution using worker threads.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8953,6 +8953,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sync-actions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sync-actions/-/sync-actions-1.0.0.tgz",
+      "integrity": "sha512-wqwKV69xS/zqJYkFbBvgSDRA/elidC7fc93G66tqXmEIWBzOxq19SwT+2AObSPMvBnUTv/oIpdM0Zl1KWtX2ZQ=="
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -10351,6 +10356,7 @@
         "get-port": "^7.0.0",
         "knex": "^3.0.0",
         "prisma": "^5.0.0",
+        "sync-actions": "^1.0.0",
         "uuid": "^11.0.0"
       },
       "optionalDependencies": {

--- a/packages/accel-record-core/package.json
+++ b/packages/accel-record-core/package.json
@@ -32,6 +32,7 @@
     "get-port": "^7.0.0",
     "knex": "^3.0.0",
     "prisma": "^5.0.0",
+    "sync-actions": "^1.0.0",
     "uuid": "^11.0.0"
   },
   "optionalDependencies": {

--- a/packages/accel-record-core/src/database/sync.ts
+++ b/packages/accel-record-core/src/database/sync.ts
@@ -1,0 +1,44 @@
+import { getKnexConfig, LogLevel } from "../database.js";
+import { sync } from "../synclib/worker.js";
+// @ts-ignore
+import SyncRpc, { stop } from "../sync-rpc/index.js";
+
+export const buildSyncClient = (
+  type: "thread" | "process",
+  params: { knexConfig: ReturnType<typeof getKnexConfig> }
+): SyncClient => {
+  return type == "process" ? new ProcessSyncClient(params) : new ThreadSyncClient(params);
+};
+
+export interface SyncClient {
+  execSQL(params: { sql: string; bindings: readonly any[]; logLevel?: LogLevel }): any;
+  stopWorker(): void;
+}
+
+export class ProcessSyncClient implements SyncClient {
+  private _rpc: any;
+  constructor(params: { knexConfig: ReturnType<typeof getKnexConfig> }) {
+    this._rpc = SyncRpc(new URL("../worker.cjs", import.meta.url).pathname, params);
+  }
+  execSQL(params: { sql: string; bindings: readonly any[]; logLevel?: LogLevel }): any {
+    return this._rpc(params);
+  }
+  stopWorker() {
+    stop();
+  }
+}
+
+export class ThreadSyncClient implements SyncClient {
+  private _rpc: ReturnType<typeof sync.launch>;
+
+  constructor(params: { knexConfig: ReturnType<typeof getKnexConfig> }) {
+    this._rpc = sync.launch();
+    this._rpc.actions.init(params);
+  }
+  execSQL(params: { sql: string; bindings: readonly any[]; logLevel?: LogLevel }): any {
+    return this._rpc?.actions?.execSQL(params);
+  }
+  stopWorker() {
+    this._rpc?.worker.terminate();
+  }
+}

--- a/packages/accel-record-core/src/synclib/worker.ts
+++ b/packages/accel-record-core/src/synclib/worker.ts
@@ -1,0 +1,39 @@
+/* eslint-disable */
+import fs from "fs";
+import Knex from "knex";
+import { defineSyncWorker } from "sync-actions";
+
+const log = (data: object) => {
+  fs.appendFile("query.log", JSON.stringify(data, null, 2) + "\n", (err) => {});
+};
+
+let knex: Knex.Knex;
+let knexConfig: any;
+
+function init(connection: { knexConfig: any }) {
+  knexConfig = connection.knexConfig;
+  knex = Knex(knexConfig);
+}
+
+function execSQL(query: { sql: string; bindings: readonly any[] }) {
+  const { sql, bindings } = query;
+  return knexConfig.client === "pg"
+    ? postgresPromise(knex, sql, bindings)
+    : knex.raw(sql, bindings);
+}
+
+function postgresPromise(knex: Knex.Knex, sql: string, bindings: readonly any[]) {
+  return new Promise(async (resolve, error) => {
+    try {
+      const { command, rowCount, rows } = await knex.raw(sql, bindings);
+      return resolve({ command, rows, rowCount });
+    } catch (err) {
+      return error(err);
+    }
+  });
+}
+
+export const sync = defineSyncWorker(import.meta.filename, {
+  init,
+  execSQL,
+});

--- a/tests/models/init.test.ts
+++ b/tests/models/init.test.ts
@@ -1,15 +1,10 @@
-import { Model, initAccelRecord } from "accel-record";
+import { initAccelRecord } from "accel-record";
 import { dbConfig } from "../vitest.setup";
 
 describe("initAccelRecord", () => {
   test("should not throw error even if called multiple times", async () => {
     const subject = () => initAccelRecord(dbConfig());
-    // for afterEach
-    const restartTx = () => Model.startTransaction();
-
     expect(async () => await subject()).not.toThrow();
-    restartTx();
     expect(async () => await subject()).not.toThrow();
-    restartTx();
   });
 });

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -8,7 +8,9 @@ import { getDatabaseConfig } from "./models/index.js";
 export const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const dbConfig = () => {
-  const config = getDatabaseConfig();
+  const nodeVersion = Number(process.versions?.node?.split(".")?.[0]);
+  const sync = isFinite(nodeVersion) && nodeVersion >= 22 ? "thread" : "process";
+  const config = { ...getDatabaseConfig(), LogLevel: "ERROR", sync } as const;
   if (process.env.DB_ENGINE == "mysql") {
     return {
       ...config,


### PR DESCRIPTION
Added the sync-actions package and implemented synchronous query execution using worker threads.

To enable it, specify sync: "thread" when calling initAccelRecord.

```ts
await initAccelRecord({
  ...getDatabaseConfig(),
  sync: "thread", // use worker threads
})
```