### PR TITLE
[accel-record] Support Prisma 6.0

### DIFF
--- a/.changeset/early-sloths-whisper.md
+++ b/.changeset/early-sloths-whisper.md
@@ -1,0 +1,7 @@
+---
+"prisma-generator-accel-record": minor
+"accel-record-core": minor
+"accel-record": minor
+---
+
+Support Prisma 6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "packages/create-accella"
       ],
       "dependencies": {
-        "@prisma/client": "^5.9.1",
+        "@prisma/client": ">=5.9.1",
         "bcrypt-ts": "^5.0.2"
       },
       "devDependencies": {
@@ -1981,12 +1981,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
-      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.0.1.tgz",
+      "integrity": "sha512-60w7kL6bUxz7M6Gs/V+OWMhwy94FshpngVmOY05TmGD0Lhk+Ac0ZgtjlL6Wll9TD4G03t4Sq1wZekNVy+Xdlbg==",
       "hasInstallScript": true,
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1998,35 +1998,35 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
-      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.0.1.tgz",
+      "integrity": "sha512-jQylgSOf7ibTVxqBacnAlVGvek6fQxJIYCQOeX2KexsfypNzXjJQSS2o5s+Mjj2Np93iSOQUaw6TvPj8syhG4w=="
     },
     "node_modules/@prisma/engines": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
-      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.0.1.tgz",
+      "integrity": "sha512-4hxzI+YQIR2uuDyVsDooFZGu5AtixbvM2psp+iayDZ4hRrAHo/YwgA17N23UWq7G6gRu18NvuNMb48qjP3DPQw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/fetch-engine": "5.22.0",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/fetch-engine": "6.0.1",
+        "@prisma/get-platform": "6.0.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
-      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ=="
+      "version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e.tgz",
+      "integrity": "sha512-JmIds0Q2/vsOmnuTJYxY4LE+sajqjYKhLtdOT6y4imojqv5d/aeVEfbBGC74t8Be1uSp0OP8lxIj2OqoKbLsfQ=="
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
-      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.0.1.tgz",
+      "integrity": "sha512-T36bWFVGeGYYSyYOj9d+O9G3sBC+pAyMC+jc45iSL63/Haq1GrYjQPgPMxrEj9m739taXrupoysRedQ+VyvM/Q==",
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.0.1",
+        "@prisma/engines-version": "5.23.0-27.5dbef10bdbfb579e07d35cc85fb1518d357cb99e",
+        "@prisma/get-platform": "6.0.1"
       }
     },
     "node_modules/@prisma/generator-helper": {
@@ -2043,11 +2043,11 @@
       "integrity": "sha512-xBs8M4bGIBUqJ/9lZM+joEJkrNaGPKMUcK3a5JqUDQtwPDaWDTq24wOpkHfoJtvNbmGtlDl9Ky5HAbctN5+x7g=="
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
-      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.0.1.tgz",
+      "integrity": "sha512-zspC9vlxAqx4E6epMPMLLBMED2VD8axDe8sPnquZ8GOsn6tiacWK0oxrGK4UAHYzYUVuMVUApJbdXB2dFpLhvg==",
       "dependencies": {
-        "@prisma/debug": "5.22.0"
+        "@prisma/debug": "6.0.1"
       }
     },
     "node_modules/@remix-run/web-blob": {
@@ -7887,18 +7887,18 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
-      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.0.1.tgz",
+      "integrity": "sha512-CaMNFHkf+DDq8zq3X/JJsQ4Koy7dyWwwtOKibkT/Am9j/tDxcfbg7+lB1Dzhx18G/+RQCMgjPYB61bhRqteNBQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.22.0"
+        "@prisma/engines": "6.0.1"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
@@ -10355,7 +10355,7 @@
         "bcrypt-ts": "^5.0.0",
         "get-port": "^7.0.0",
         "knex": "^3.0.0",
-        "prisma": "^5.0.0",
+        "prisma": ">=5.0.0",
         "sync-actions": "^1.0.0",
         "uuid": "^11.0.0"
       },
@@ -10403,8 +10403,8 @@
       "version": "1.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client": "^5.0.0",
-        "@prisma/generator-helper": "^5.0.0",
+        "@prisma/client": ">=5.0.0",
+        "@prisma/generator-helper": ">=5.0.0",
         "esbuild": ">=0.21.0",
         "prettier": "^3.0.0"
       },
@@ -10413,7 +10413,7 @@
       },
       "devDependencies": {
         "@types/node": "^17.0.0",
-        "prisma": "^5.0.0",
+        "prisma": ">=5.0.0",
         "typescript": "^5.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vitest": "^1.3.0"
   },
   "dependencies": {
-    "@prisma/client": "^5.9.1",
+    "@prisma/client": ">=5.9.1",
     "bcrypt-ts": "^5.0.2"
   }
 }

--- a/packages/accel-record-core/package.json
+++ b/packages/accel-record-core/package.json
@@ -31,7 +31,7 @@
     "bcrypt-ts": "^5.0.0",
     "get-port": "^7.0.0",
     "knex": "^3.0.0",
-    "prisma": "^5.0.0",
+    "prisma": ">=5.0.0",
     "sync-actions": "^1.0.0",
     "uuid": "^11.0.0"
   },

--- a/packages/accel-record-core/src/model/field.ts
+++ b/packages/accel-record-core/src/model/field.ts
@@ -101,7 +101,9 @@ export class Field {
    * @returns True if the default value is "uuid7", false otherwise.
    */
   get defaultIsUuid7() {
-    return this.default != undefined && this.default.name === "uuid(7)";
+    if (!this.default) return false;
+    if (this.default.name === "uuid(7)") return true;
+    return this.default.name === "uuid" && this.default.args[0] == 7;
   }
 
   /**

--- a/packages/prisma-generator-accel-record/package.json
+++ b/packages/prisma-generator-accel-record/package.json
@@ -29,14 +29,14 @@
     "dist"
   ],
   "dependencies": {
-    "@prisma/client": "^5.0.0",
-    "@prisma/generator-helper": "^5.0.0",
+    "@prisma/client": ">=5.0.0",
+    "@prisma/generator-helper": ">=5.0.0",
     "esbuild": ">=0.21.0",
     "prettier": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.0",
-    "prisma": "^5.0.0",
+    "prisma": ">=5.0.0",
     "typescript": "^5.0.0"
   },
   "author": "koyopro",


### PR DESCRIPTION
- Allowed version 6 for Prisma dependency
- Adapted to changes in the uuid column specification