### PR TITLE
[prisma-generator-accel-record] Disable sync-actions launch to prevent the process from hanging

### DIFF
--- a/.changeset/twelve-carpets-relax.md
+++ b/.changeset/twelve-carpets-relax.md
@@ -1,0 +1,5 @@
+---
+"prisma-generator-accel-record": patch
+---
+
+Disable sync-actions launch to prevent the process from hanging

--- a/packages/prisma-generator-accel-record/src/generators/relation.ts
+++ b/packages/prisma-generator-accel-record/src/generators/relation.ts
@@ -11,6 +11,8 @@ const loadModels = async (options: GeneratorOptions) => {
   if (!fs.existsSync(filePath)) return undefined;
   try {
     buildFile(filePath, outfile);
+    // Disable sync-actions launch to prevent the process from hanging
+    process.env.DISABLE_SYNC_ACTIONS = "1";
     return await eval(`import('${outfile}')`);
   } catch {
     console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,10 @@ import { initAccelRecord } from "accel-record";
 import "accel-record/errors";
 import "accel-record/search";
 import { getDatabaseConfig, User } from "../tests/models/index.js";
+import { worker } from "../tests/models/workers/sample.js";
 
 initAccelRecord(getDatabaseConfig()).then(() => {
   // User.create({ email: `${Date.now()}@example.com` });
   console.log(User.count());
+  worker.terminate();
 });

--- a/tests/models/employee.ts
+++ b/tests/models/employee.ts
@@ -1,3 +1,9 @@
 import { ApplicationRecord } from "./applicationRecord.js";
+import { actions } from "./workers/sample.js";
 
-export class EmployeeModel extends ApplicationRecord {}
+export class EmployeeModel extends ApplicationRecord {
+  // For testing prisma-generator-accel-record
+  methodWithSyncAction() {
+    actions.sleep(1000);
+  }
+}

--- a/tests/models/workers/sample.ts
+++ b/tests/models/workers/sample.ts
@@ -1,0 +1,5 @@
+import { defineSyncWorker } from "sync-actions";
+
+export const { actions, worker } = defineSyncWorker(import.meta.filename, {
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+}).launch();


### PR DESCRIPTION
When loading the model with prisma-generator-accel-record, there was an issue where the eval would not finish if sync-actions were launched. This was resolved by setting the environment variable DISABLE_SYNC_ACTIONS to disable sync-actions.
