### PR TITLE
[accella] feat: Load the files in the config/initializers directory during initialization

### DIFF
--- a/.changeset/hip-rings-tie.md
+++ b/.changeset/hip-rings-tie.md
@@ -1,0 +1,5 @@
+---
+"accella": minor
+---
+
+feat: Load the files in the config/initializers directory during initialization

--- a/examples/basics/src/config/initializers/database.ts
+++ b/examples/basics/src/config/initializers/database.ts
@@ -1,5 +1,5 @@
 import { initAccelRecord } from "accel-record";
-import { getDatabaseConfig } from "../models";
+import { getDatabaseConfig } from "../../models";
 
 export default async () => {
   await initAccelRecord(getDatabaseConfig());

--- a/packages/accella/src/initialize.ts
+++ b/packages/accella/src/initialize.ts
@@ -1,0 +1,16 @@
+import fg from "fast-glob";
+import { Accel } from "./index.js";
+
+export const runInitializers = async () => {
+  const dir = Accel.root.child("src/config/initializers/");
+  const files = await fg.glob(`*.{ts,js,mjs,cjs}`, { cwd: dir.toString() });
+  for (const file of files) {
+    const path = dir.child(file).toString();
+    try {
+      const initializer = (await import(/* @vite-ignore */ path)).default;
+      if (initializer && typeof initializer === "function") await initializer();
+    } catch (error) {
+      console.warn(`Error running initializer of ${path}`, error);
+    }
+  }
+};

--- a/packages/accella/src/middleware.ts
+++ b/packages/accella/src/middleware.ts
@@ -2,19 +2,10 @@ import { RecordNotFound } from "accel-record/errors";
 import { RequestParameters } from "accel-web";
 import { APIContext } from "astro";
 import { ZodError } from "zod";
-import { Accel } from "./index.js";
+import { runInitializers } from "./initialize.js";
 import { getSession } from "./session";
 
-const setup = async () => {
-  const path = Accel.root.child("src/config/database").toString();
-  try {
-    const setupDatabase = (await import(/* @vite-ignore */ path)).default;
-    await setupDatabase();
-  } catch (error) {
-    console.warn("Error setting up database", error);
-  }
-};
-await setup();
+await runInitializers();
 
 export const onRequest = async (context: APIContext, next: any) => {
   const { cookies, request, params, locals } = context;

--- a/src/config/initializers/sample.ts
+++ b/src/config/initializers/sample.ts
@@ -1,0 +1,9 @@
+// Sample Initializer for test
+
+let initialized = false;
+
+export default () => {
+  initialized = true;
+};
+
+export const getInitialized = () => initialized;

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,7 @@
+import { getInitialized } from "../src/config/initializers/sample";
+
+test("config/initializers", async () => {
+  expect(getInitialized()).toBe(false);
+  await import("accella/middleware");
+  expect(getInitialized()).toBe(true);
+});


### PR DESCRIPTION
Added runInitializers() to load and execute modules under the config/initializers/ directory during initialization