### PR TITLE
[accel-record] Added an interface to define validations for the Model as static properties

### DIFF
--- a/.changeset/two-tigers-share.md
+++ b/.changeset/two-tigers-share.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": minor
+"accel-record": minor
+---
+
+Added an interface to define validations for the Model as static properties

--- a/packages/accel-record-core/src/model/validations.ts
+++ b/packages/accel-record-core/src/model/validations.ts
@@ -1,7 +1,7 @@
 import { Collection } from "../associations/collectionProxy.js";
 import { HasManyAssociation } from "../associations/hasManyAssociation.js";
 import { HasOneAssociation } from "../associations/hasOneAssociation.js";
-import { Model, ModelBase } from "../index.js";
+import { FormModel, Model, ModelBase } from "../index.js";
 import { Meta } from "../meta.js";
 import { Errors } from "../validation/errors.js";
 import { AcceptanceOptions, AcceptanceValidator } from "../validation/validator/acceptance.js";
@@ -179,10 +179,18 @@ type ValidateItem<T, K> = [K | K[], ValidatesOptions<T>] | typeof Validator<any>
  * }
  * ```
  */
-export const validates = <T extends typeof Model, K extends keyof Meta<T>["CreateInput"] & string>(
+export function validates<T extends typeof Model, K extends keyof Meta<T>["CreateInput"] & string>(
   klass: T,
   list: ValidateItem<T, K>[]
-): ValidateItem<any, any>[] => {
+): ValidateItem<any, any>[];
+export function validates<T extends typeof FormModel, K extends keyof InstanceType<T> & string>(
+  klass: T,
+  list: ValidateItem<T, K>[]
+): ValidateItem<any, any>[];
+export function validates<T, K extends string>(
+  klass: T,
+  list: ValidateItem<T, K>[]
+): ValidateItem<any, any>[] {
   const base = Object.getPrototypeOf(klass).validations ?? [];
   return [...base, ...list];
-};
+}

--- a/packages/accel-record-core/src/model/validations.ts
+++ b/packages/accel-record-core/src/model/validations.ts
@@ -45,8 +45,7 @@ export class Validations {
   isValid<T extends ModelBase & Validations>(this: T): boolean {
     this.runBeforeCallbacks("validation");
     this.errors.clearAll();
-    this.validateAttributes();
-    this.validateAssociations();
+    this.runValidations();
     this.runAfterCallbacks("validation");
     return this.errors.isEmpty();
   }
@@ -81,6 +80,25 @@ export class Validations {
    */
   validate<T extends Model>(this: T): boolean {
     return this.isValid();
+  }
+
+  protected runValidations<T extends ModelBase & Validations>(this: T) {
+    this.validateWithStaticProps();
+    this.validateAttributes();
+    this.validateAssociations();
+  }
+
+  validateWithStaticProps<T extends ModelBase & Validations>(this: T) {
+    const validations = (this.constructor as any)["validations"];
+    if (Array.isArray(validations)) {
+      for (const validation of validations) {
+        if (typeof validation === "function") {
+          new validation(this).validate();
+        } else {
+          this.validates(validation[0], validation[1]);
+        }
+      }
+    }
   }
 
   /**
@@ -135,3 +153,36 @@ export class Validations {
     }
   }
 }
+
+type ValidateItem<T, K> = [K | K[], ValidatesOptions<T>] | typeof Validator<any>;
+
+/**
+ * Combines the base validations of a given model class with additional validation items.
+ *
+ * @returns An array containing the combined base and additional validation items.
+ * @example
+ * ```ts
+ * export class ValidateSampleModel extends ApplicationRecord {
+ *   static validations = validates(this, [
+ *     ["accepted", { acceptance: true }],
+ *     [["key", "size"], { presence: true }],
+ *     MyValidator,
+ *   ]);
+ * }
+ *
+ * class MyValidator extends Validator<{ key: string | undefined }> {
+ *   validate() {
+ *     if (this.record.key === "xs") {
+ *       this.errors.add("key", "should not be xs");
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export const validates = <T extends typeof Model, K extends keyof Meta<T>["CreateInput"] & string>(
+  klass: T,
+  list: ValidateItem<T, K>[]
+): ValidateItem<any, any>[] => {
+  const base = Object.getPrototypeOf(klass).validations ?? [];
+  return [...base, ...list];
+};

--- a/packages/accel-record/README-ja.md
+++ b/packages/accel-record/README-ja.md
@@ -930,12 +930,11 @@ newUser.age; // => 20
 
 ```ts
 // src/models/user.ts
+import { validates } from "accel-record/validations";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 export class UserModel extends ApplicationRecord {
-  override validateAttributes() {
-    this.validates("firstName", { presence: true });
-  }
+  static validations = validates(this, [["firstName", { presence: true }]]);
 }
 ```
 
@@ -972,7 +971,8 @@ User.create({ firstName: "" }); // => Error: Failed to create
 
 ### バリデーションの定義
 
-BaseModelの `validateAttributes`メソッドをオーバーライドすることで、バリデーションを定義することができます。
+`validates()`関数を利用しモデルクラスに`validations`プロパティを用意することで、バリデーションを定義することができます。
+または、BaseModelの`validateAttributes()`メソッドをオーバーライドする方法もあります。
 
 ```ts
 // prisma/schema.prisma
@@ -989,27 +989,35 @@ model ValidateSample {
 ```ts
 // ./models/validateSample.ts
 import { Validator } from "accel-record";
+import { validates } from "accel-record/validations";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 export class ValidateSampleModel extends ApplicationRecord {
-  // validateAttributesメソッドをオーバーライドして、バリデーションを定義します。
-  override validateAttributes() {
+  static validations = validates(this, [
     // よく使われるバリデーションは、バリデーションヘルパーを利用して簡単に記述ができます。
-    this.validates("accepted", { acceptance: true });
-    this.validates("pattern", {
-      length: { minimum: 2, maximum: 5 },
-      format: { with: /^[a-z]+$/, message: "only allows lowercase letters" },
-    });
-    this.validates("size", { inclusion: { in: ["small", "medium", "large"] } });
-    this.validates(["key", "size"], { presence: true });
+    ["accepted", { acceptance: true }],
+    [
+      "pattern",
+      {
+        length: { minimum: 2, maximum: 5 },
+        format: { with: /^[a-z]+$/, message: "only allows lowercase letters" },
+      },
+    ],
+    ["size", { inclusion: { in: ["small", "medium", "large"] } }],
+    [["key", "size"], { presence: true }],
+
+    // カスタムバリデータの利用例
+    MyValidator,
+  ]);
+
+  // validateAttributesメソッドをオーバーライドして、バリデーションを定義することもできます。
+  override validateAttributes() {
     this.validates("key", { uniqueness: true });
 
     // 独自のロジックでバリデーションを行う場合は、 errros.add メソッドを利用してエラーメッセージを追加します。
     if (this.key && !/^[a-z]$/.test(this.key[0])) {
       this.errors.add("key", "should start with a lowercase letter");
     }
-    // カスタムバリデータの利用例
-    this.validatesWith(new MyValidator(this));
   }
 }
 
@@ -1197,12 +1205,11 @@ errors.messages.[messageKey]
 ```
 
 ```ts
+import { validates } from "accel-record/validations";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 class UserModel extends ApplicationRecord {
-  override validateAttributes() {
-    this.validates("firstName", { presence: true });
-  }
+  static validations = validates(this, [["firstName", { presence: true }]]);
 }
 ```
 
@@ -1376,16 +1383,17 @@ Formオブジェクトは、通常のモデルとは切り分けてバリデー�
 ```ts
 import { FormModel } from "accel-record";
 import { attributes } from "accel-record/attributes";
+import { validates } from "accel-record/validations";
 
 class MyForm extends FormModel {
   title = attributes.string();
   priority = attributes.integer(3);
   dueDate = attributes.date();
 
-  override validateAttributes() {
-    this.validates("title", { presence: true });
-    this.validates("priority", { numericality: { between: [1, 5] } });
-  }
+  static validations = validates(this, [
+    ["title", { presence: true }],
+    ["priority", { numericality: { between: [1, 5] } }],
+  ]);
 
   save() {
     if (this.isInvalid()) return false;

--- a/packages/accel-record/package.json
+++ b/packages/accel-record/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/enums.d.ts",
       "default": "./dist/enums.js"
     },
+    "./validations": {
+      "types": "./dist/validations.d.ts",
+      "default": "./dist/validations.js"
+    },
     "./search": {
       "types": "./dist/search.d.ts",
       "default": "./dist/search.js"

--- a/packages/accel-record/src/validations.ts
+++ b/packages/accel-record/src/validations.ts
@@ -1,0 +1,1 @@
+export * from "accel-record-core/dist/model/validations.js";

--- a/tests/models/model/validation.test-d.ts
+++ b/tests/models/model/validation.test-d.ts
@@ -1,0 +1,20 @@
+import { validates } from "accel-record-core/dist/model/validations";
+import { ValidateSampleModel } from "../validateSample";
+
+test("validates()", () => {
+  validates(ValidateSampleModel, [
+    ["accepted", { acceptance: true }],
+    [["key", "size"], { presence: true }],
+    ["accepted", { acceptance: true }],
+    ["key", { uniqueness: { scope: ["size", "id"] } }],
+
+    // @ts-expect-error
+    ["foo", { acceptance: true }],
+    // @ts-expect-error
+    [["key", "foo"], { presence: true }],
+    // @ts-expect-error
+    ["accepted", { foo: true }],
+    // @ts-expect-error
+    ["key", { uniqueness: { scope: ["size", "foo"] } }],
+  ]);
+});

--- a/tests/models/model/validation.test-d.ts
+++ b/tests/models/model/validation.test-d.ts
@@ -1,4 +1,4 @@
-import { validates } from "accel-record-core/dist/model/validations";
+import { validates } from "accel-record/validations";
 import { ValidateSampleModel } from "../validateSample";
 
 test("validates()", () => {

--- a/tests/models/model/validation.test-d.ts
+++ b/tests/models/model/validation.test-d.ts
@@ -2,19 +2,16 @@ import { validates } from "accel-record-core/dist/model/validations";
 import { ValidateSampleModel } from "../validateSample";
 
 test("validates()", () => {
-  validates(ValidateSampleModel, [
-    ["accepted", { acceptance: true }],
-    [["key", "size"], { presence: true }],
-    ["accepted", { acceptance: true }],
-    ["key", { uniqueness: { scope: ["size", "id"] } }],
-
-    // @ts-expect-error
-    ["foo", { acceptance: true }],
-    // @ts-expect-error
-    [["key", "foo"], { presence: true }],
-    // @ts-expect-error
-    ["accepted", { foo: true }],
-    // @ts-expect-error
-    ["key", { uniqueness: { scope: ["size", "foo"] } }],
-  ]);
+  validates(ValidateSampleModel, [["accepted", { acceptance: true }]]);
+  validates(ValidateSampleModel, [[["key", "size"], { presence: true }]]);
+  validates(ValidateSampleModel, [["accepted", { acceptance: true }]]);
+  validates(ValidateSampleModel, [["key", { uniqueness: { scope: ["size", "id"] } }]]);
+  // @ts-expect-error
+  validates(ValidateSampleModel, [["foo", { acceptance: true }]]);
+  // @ts-expect-error
+  validates(ValidateSampleModel, [[["key", "foo"], { presence: true }]]);
+  // @ts-expect-error
+  validates(ValidateSampleModel, [["accepted", { foo: true }]]);
+  // @ts-expect-error
+  validates(ValidateSampleModel, [["key", { uniqueness: { scope: ["size", "foo"] } }]]);
 });

--- a/tests/models/validateFormModel.test.ts
+++ b/tests/models/validateFormModel.test.ts
@@ -1,0 +1,24 @@
+import { FormModel } from "accel-record";
+import { attributes } from "accel-record/attributes";
+import { validates } from "accel-record/validations";
+
+class SampleForm extends FormModel {
+  static validations = validates(this, [
+    [
+      "count",
+      {
+        numericality: { between: [0, 10] },
+      },
+    ],
+  ]);
+
+  count = attributes.integer(0);
+}
+
+test(".validations", () => {
+  const form = SampleForm.build({ count: 5 });
+  expect(form.isValid()).toBe(true);
+  form.count = 11;
+  expect(form.isValid()).toBe(false);
+  expect(form.errors.fullMessages).toEqual(["Count must be between 0 and 10"]);
+});

--- a/tests/models/validateSample.ts
+++ b/tests/models/validateSample.ts
@@ -1,4 +1,5 @@
 import { Validator } from "accel-record";
+import { validates } from "accel-record-core/dist/model/validations.js";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 class MyValidator extends Validator<{ key: string | undefined }> {
@@ -9,13 +10,24 @@ class MyValidator extends Validator<{ key: string | undefined }> {
   }
 }
 
-export class ValidateSampleModel extends ApplicationRecord {
+class ValidateSampleBase extends ApplicationRecord {
+  static validations: any = validates(this, [MyValidator]);
+}
+
+export class ValidateSampleModel extends ValidateSampleBase {
+  static validations = validates(this, [
+    ["accepted", { acceptance: true }],
+    [
+      "pattern",
+      {
+        length: { minimum: 2, maximum: 5 },
+        format: { with: /^[a-z]+$/, message: "only allows lowercase letters" },
+      },
+    ],
+    [["key", "size"], { presence: true }],
+  ]);
+
   override validateAttributes() {
-    this.validates("accepted", { acceptance: true });
-    this.validates("pattern", {
-      length: { minimum: 2, maximum: 5 },
-      format: { with: /^[a-z]+$/, message: "only allows lowercase letters" },
-    });
     this.validates("size", { inclusion: { in: ["small", "medium", "large"] } });
 
     this.validates(["key", "size"], { presence: true });
@@ -24,6 +36,5 @@ export class ValidateSampleModel extends ApplicationRecord {
     if (this.key && !/^[a-z]$/.test(this.key[0])) {
       this.errors.add("key", "should start with a lowercase letter");
     }
-    this.validatesWith(new MyValidator(this));
   }
 }

--- a/tests/models/validateSample.ts
+++ b/tests/models/validateSample.ts
@@ -1,5 +1,5 @@
 import { Validator } from "accel-record";
-import { validates } from "accel-record-core/dist/model/validations.js";
+import { validates } from "accel-record/validations";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 class MyValidator extends Validator<{ key: string | undefined }> {


### PR DESCRIPTION
You can define validations by using the `validates()` function and adding a `validations` property to the model class.

```ts
// ./models/validateSample.ts
import { Validator } from "accel-record";
import { validates } from "accel-record/validations";
import { ApplicationRecord } from "./applicationRecord.js";

export class ValidateSampleModel extends ApplicationRecord {
  static validations = validates(this, [
    // Common validations can be easily written using validation helpers.
    ["accepted", { acceptance: true }],
    [
      "pattern",
      {
        length: { minimum: 2, maximum: 5 },
        format: { with: /^[a-z]+$/, message: "only allows lowercase letters" },
      },
    ],
    ["size", { inclusion: { in: ["small", "medium", "large"] } }],
    [["key", "size"], { presence: true }],

    // Example of using a custom validator
    MyValidator,
  ]);
}

// Custom validators inherit from Validator and implement the validate method.
class MyValidator extends Validator<{ key: string | undefined }> {
  validate() {
    if (this.record.key === "xs") {
      this.errors.add("key", "should not be xs");
    }
  }
}
```