### PR TITLE
[accel-record] marge arrays in Mix

### DIFF
--- a/.changeset/silly-apples-tie.md
+++ b/.changeset/silly-apples-tie.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": patch
+"accel-record": patch
+---
+
+Merge arrays in Mix()

--- a/packages/accel-record-core/src/model/validations.ts
+++ b/packages/accel-record-core/src/model/validations.ts
@@ -1,7 +1,7 @@
 import { Collection } from "../associations/collectionProxy.js";
 import { HasManyAssociation } from "../associations/hasManyAssociation.js";
 import { HasOneAssociation } from "../associations/hasOneAssociation.js";
-import { FormModel, Model, ModelBase } from "../index.js";
+import { Model, ModelBase } from "../index.js";
 import { Meta } from "../meta.js";
 import { Errors } from "../validation/errors.js";
 import { AcceptanceOptions, AcceptanceValidator } from "../validation/validator/acceptance.js";
@@ -183,10 +183,10 @@ export function validates<T extends typeof Model, K extends keyof Meta<T>["Creat
   klass: T,
   list: ValidateItem<T, K>[]
 ): ValidateItem<any, any>[];
-export function validates<T extends typeof FormModel, K extends keyof InstanceType<T> & string>(
-  klass: T,
-  list: ValidateItem<T, K>[]
-): ValidateItem<any, any>[];
+export function validates<
+  T extends { new (...args: any): any },
+  K extends keyof InstanceType<T> & string,
+>(klass: T, list: ValidateItem<T, K>[]): ValidateItem<any, any>[];
 export function validates<T, K extends string>(
   klass: T,
   list: ValidateItem<T, K>[]

--- a/packages/accel-record-core/src/utils.ts
+++ b/packages/accel-record-core/src/utils.ts
@@ -84,7 +84,15 @@ const assign = (target: object, source: object, key: string) => {
   const desc = Object.getOwnPropertyDescriptor(source, key);
   const targetDesc = findMethod(target, key);
 
-  if (typeof targetDesc?.value == "function" && typeof desc?.value == "function") {
+  if (Array.isArray(targetDesc?.value) && Array.isArray(desc?.value)) {
+    // merge arrays
+    Object.defineProperty(target, key, {
+      value: [...targetDesc.value, ...desc.value],
+      enumerable: targetDesc.enumerable,
+      writable: true,
+      configurable: true,
+    });
+  } else if (typeof targetDesc?.value == "function" && typeof desc?.value == "function") {
     // already has a method, so we need to wrap it
     Object.defineProperty(target, key, {
       value: function (this: any, ...args: any[]) {

--- a/tests/models/mix.test.ts
+++ b/tests/models/mix.test.ts
@@ -3,6 +3,8 @@ import { Mix } from "accel-record-core";
 class A {
   static a = "a";
 
+  static validations = ["a"];
+
   a = "a";
   errors: string[] = [];
 
@@ -24,6 +26,8 @@ class AB extends Mix(A, B) {}
 class C {
   static c = "c";
 
+  static validations = ["c"];
+
   c = "c";
 
   validate<T extends A>(this: T) {
@@ -40,6 +44,8 @@ test("mix", () => {
 
   expect(ABC.a).toBe("a");
   expect(ABC.c).toBe("c");
+
+  expect(ABC.validations).toEqual(["a", "c"]);
 
   const ab = new AB();
   expect(ab.a).toBe("a");


### PR DESCRIPTION
1. `hasSecurePassword()` use static validations property instead of validateAttributes()

2. The arrays of the class passed to Mix() are now merged.


```ts
import { Mix } from "accel-record-core";

class A {
  static array = ["a"];
}

class B {
  static array = ["b"];
}

class AB extends Mix(A, B) {}

console.log(AB.array); // => ["a", "b"]
```