### PR TITLE
[accel-web] Fixed searchFormFor() interface

### DIFF
--- a/.changeset/thirty-oranges-accept.md
+++ b/.changeset/thirty-oranges-accept.md
@@ -1,0 +1,5 @@
+---
+"accel-web": patch
+---
+
+Fixed the second argument of searchFormFor() to be optional instead of mandatory.

--- a/packages/accel-web/src/searchFormFor.ts
+++ b/packages/accel-web/src/searchFormFor.ts
@@ -21,6 +21,6 @@ import { formFor, FormForOptions } from "./form/index.js";
  * </Form>
  * ```
  */
-export const searchFormFor = (s: Search<any>, options: FormForOptions) => {
+export const searchFormFor = (s: Search<any>, options?: FormForOptions) => {
   return formFor(s, { namespace: "q", ...options });
 };

--- a/tests/web/searchFormFor.test.ts
+++ b/tests/web/searchFormFor.test.ts
@@ -3,8 +3,16 @@ import { User } from "../models";
 
 test("searchFormFor", async () => {
   const search = User.search({});
-  const { Form, TextField, Submit } = searchFormFor(search, { namespace: "query" });
-  expect(Form).toBeDefined();
-  expect(TextField).toBeDefined();
-  expect(Submit).toBeDefined();
+  {
+    const { Form, TextField, Submit } = searchFormFor(search);
+    expect(Form).toBeDefined();
+    expect(TextField).toBeDefined();
+    expect(Submit).toBeDefined();
+  }
+  {
+    const { Form, TextField, Submit } = searchFormFor(search, { namespace: "query" });
+    expect(Form).toBeDefined();
+    expect(TextField).toBeDefined();
+    expect(Submit).toBeDefined();
+  }
 });


### PR DESCRIPTION
Fixed the second argument of searchFormFor() to be optional instead of mandatory.