### PR TITLE
[accella] Fixed an error of runInitializers about glob import

### DIFF
--- a/.changeset/rude-candles-talk.md
+++ b/.changeset/rude-candles-talk.md
@@ -1,0 +1,5 @@
+---
+"accella": patch
+---
+
+Fixed an error of runInitializers about glob import

--- a/packages/accella/src/initialize.ts
+++ b/packages/accella/src/initialize.ts
@@ -1,5 +1,5 @@
 export const runInitializers = async () => {
-  const modules = import.meta.glob("src/config/initializers/*");
+  const modules = import.meta.glob("/src/config/initializers/*");
   for (const path in modules) {
     try {
       const initializer = ((await modules[path]()) as any).default;


### PR DESCRIPTION
> Invalid glob import syntax: pattern must start with "." or "/" 

![image](https://github.com/user-attachments/assets/a8a87fec-5c03-4193-a2bc-97f25955571e)
