### PR TITLE
[prisma-generator-accel-record] Fixed an issue about schemaDir

### DIFF
--- a/.changeset/real-trainers-study.md
+++ b/.changeset/real-trainers-study.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": patch
+"accel-record": patch
+---
+
+Adjusted to match the changes in the schemaDir of prisma-generator-accel-record.

--- a/.changeset/shiny-impalas-enjoy.md
+++ b/.changeset/shiny-impalas-enjoy.md
@@ -1,0 +1,5 @@
+---
+"prisma-generator-accel-record": patch
+---
+
+Fixed an issue where the schemaDir was one level deeper than necessary.

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -1,5 +1,4 @@
 import { DataSource } from "@prisma/generator-helper";
-import { join } from "path";
 import { Collection } from "./associations/collectionProxy.js";
 import { HasManyAssociation } from "./associations/hasManyAssociation.js";
 import { HasOneAssociation } from "./associations/hasOneAssociation.js";
@@ -65,7 +64,7 @@ export const generateDatabaseConfig = (
   schemaDir: string
 ) => {
   let url: string | null = null;
-  const prismaDir = new URL(join(basePath, schemaDir));
+  const prismaDir = new URL(schemaDir, basePath);
   if (dataSource.url.fromEnvVar) {
     const envVar = dataSource.url.fromEnvVar;
     url = (import.meta as any).env?.[envVar] ?? process.env?.[envVar] ?? null;

--- a/packages/prisma-generator-accel-record/src/generators/index.ts
+++ b/packages/prisma-generator-accel-record/src/generators/index.ts
@@ -1,6 +1,6 @@
 import { DMMF, GeneratorOptions } from "@prisma/generator-helper";
+import path, { dirname } from "path";
 import { generateTypes } from "./type";
-import path, { dirname, join } from "path";
 
 export const generateIndex = async (options: GeneratorOptions) => {
   return [
@@ -21,7 +21,7 @@ import { type DataSource } from "@prisma/generator-helper";
 
 const generateSchema = (options: GeneratorOptions) => {
   const outputPath = options.generator.output!.value!;
-  const relativePath = path.relative(join(outputPath, "index.ts"), options.schemaPath);
+  const relativePath = path.relative(outputPath, options.schemaPath);
   const schemaDir = dirname(relativePath);
   const db = options.datasources.find((v) => v.name == "db");
   if (!["mysql", "postgresql", "sqlite"].includes(db?.provider ?? "")) {
@@ -30,7 +30,7 @@ const generateSchema = (options: GeneratorOptions) => {
   // remove sourceFilePath
   const { sourceFilePath: _, ...dataSource } = db as any;
   return `
-export const schemaDir = "${schemaDir}";
+export const schemaDir = "${schemaDir}/";
 export const dataSource = ${JSON.stringify(dataSource, null, 2)} as DataSource;
 
 /**

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -770,7 +770,7 @@ type BookMeta = {
 registerModel(Book);
 
 
-export const schemaDir = "../../prisma_mysql";
+export const schemaDir = "../prisma_mysql/";
 export const dataSource = {
   "name": "db",
   "provider": "mysql",

--- a/tests/models/dataSource.test.ts
+++ b/tests/models/dataSource.test.ts
@@ -4,7 +4,7 @@ import { dbConfig } from "../vitest.setup";
 test("dataSource", () => {
   switch (dbConfig().type) {
     case "mysql":
-      expect(schemaDir).toBe("../../prisma_mysql");
+      expect(schemaDir).toBe("../prisma_mysql/");
       expect(dataSource).toMatchObject({
         name: "db",
         provider: "mysql",
@@ -17,7 +17,7 @@ test("dataSource", () => {
       });
       break;
     case "sqlite":
-      expect(schemaDir).toBe("../../prisma");
+      expect(schemaDir).toBe("../prisma/");
       expect(dataSource).toMatchObject({
         name: "db",
         provider: "sqlite",
@@ -30,7 +30,7 @@ test("dataSource", () => {
       });
       break;
     case "postgresql":
-      expect(schemaDir).toBe("../../prisma_pg");
+      expect(schemaDir).toBe("../prisma_pg/");
       expect(dataSource).toMatchObject({
         name: "db",
         provider: "postgresql",
@@ -52,22 +52,22 @@ test("getDatabaseConfig()", () => {
       expect(config).toMatchObject({
         type: "mysql",
         datasourceUrl: "mysql://root:@localhost:3306/accel_test1",
-        prismaDir: new RegExp("/.+/tests/prisma_mysql"),
       });
+      expect(config.prismaDir).toMatch(new RegExp("/.+/tests/prisma_mysql/"));
       break;
     case "sqlite":
       expect(config).toMatchObject({
         type: "sqlite",
-        datasourceUrl: new RegExp("/.+/tests/prisma/test.db"),
-        prismaDir: new RegExp("/.+/tests/prisma"),
       });
+      expect(config.datasourceUrl).toMatch(new RegExp("/.+/tests/prisma/test.db"));
+      expect(config.prismaDir).toMatch(new RegExp("/.+/tests/prisma/"));
       break;
     case "postgresql":
       expect(config).toMatchObject({
         type: "postgresql",
         datasourceUrl: "postgresql://test:password@localhost:5432/accel_test1",
-        prismaDir: new RegExp("/.+/tests/prisma_pg"),
       });
+      expect(config.prismaDir).toMatch(new RegExp("/.+/tests/prisma_pg/"));
       break;
   }
 });


### PR DESCRIPTION
Fixed an issue where the schemaDir was one level deeper than necessary.

```diff
-   export const schemaDir = "../../prisma";
+   export const schemaDir = "../prisma/";
```