### PR TITLE
[accel-record] Changed to use sourceFilePath for calculating datasourceUrl

### DIFF
--- a/.changeset/four-lamps-march.md
+++ b/.changeset/four-lamps-march.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": patch
+"accel-record": patch
+---
+
+Changed to use `sourceFilePath` for calculating `datasourceUrl`. This fix resolves an issue where enabling `prismaSchemaFolder` and specifying a relative path for the SQLite datasource URL would cause a mismatch between the generated database file and the reference path.

--- a/.changeset/smooth-kiwis-remain.md
+++ b/.changeset/smooth-kiwis-remain.md
@@ -1,0 +1,5 @@
+---
+"prisma-generator-accel-record": patch
+---
+
+The `sourceFilePath` is now output separately from `schemaDir` and is used in `generateDatabaseConfig()`.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm run test:sqlite
       - run: npm run generate:pg
       - run: npm run test:pg
+      - run: npm run check:schema
     parameters:
       node_image:
         type: string

--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,5 @@ tsconfig.vitest-temp.json
 *.db-journal
 .DS_Store
 
+tests/check/
 tmp/

--- a/examples/web_astro/src/models/_types.ts
+++ b/examples/web_astro/src/models/_types.ts
@@ -160,7 +160,8 @@ type TodoMeta = {
 registerModel(Todo);
 defineEnumTextAttribute(TodoModel, Todo, "status");
 
-export const schemaDir = "../../../prisma";
+export const schemaDir = "../../prisma/";
+export const sourceFilePath = "../../prisma/schema.prisma";
 export const dataSource = {
   name: "db",
   provider: "mysql",
@@ -176,4 +177,4 @@ export const dataSource = {
  * Retrieves the database connection settings based on the Prisma schema file.
  */
 export const getDatabaseConfig = () =>
-  generateDatabaseConfig(dataSource, import.meta.url, schemaDir);
+  generateDatabaseConfig(dataSource, import.meta.url, schemaDir, sourceFilePath);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:mysql": "DB_ENGINE=mysql vitest --typecheck",
     "test:pg": "DB_ENGINE=pg vitest --typecheck",
     "sample": "tsc -p . && node dist/src/index.js",
+    "check:schema": "npx tsx src/checkSchema.ts",
     "check-package": "cd examples/minimal && npm run check && cd ../.."
   },
   "repository": {

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -61,7 +61,8 @@ export const registerModel = (model: any) => {
 export const generateDatabaseConfig = (
   dataSource: DataSource,
   basePath: string,
-  schemaDir: string
+  schemaDir: string,
+  sourceFilePath: string
 ) => {
   let url: string | null = null;
   const prismaDir = new URL(schemaDir, basePath);
@@ -69,7 +70,7 @@ export const generateDatabaseConfig = (
     const envVar = dataSource.url.fromEnvVar;
     url = (import.meta as any).env?.[envVar] ?? process.env?.[envVar] ?? null;
     if (url?.startsWith("file:")) {
-      url = new URL(url, prismaDir).pathname;
+      url = new URL(url, new URL(sourceFilePath, basePath)).pathname;
     }
   }
   return {

--- a/packages/prisma-generator-accel-record/src/generators/index.ts
+++ b/packages/prisma-generator-accel-record/src/generators/index.ts
@@ -28,15 +28,16 @@ const generateSchema = (options: GeneratorOptions) => {
     throw new Error(`db provider must be one of mysql, postgresql, sqlite: ${db?.provider}`);
   }
   // remove sourceFilePath
-  const { sourceFilePath: _, ...dataSource } = db as any;
+  const { sourceFilePath, ...dataSource } = db as any;
   return `
 export const schemaDir = "${schemaDir}/";
+export const sourceFilePath = "${path.relative(outputPath, sourceFilePath)}";
 export const dataSource = ${JSON.stringify(dataSource, null, 2)} as DataSource;
 
 /**
  * Retrieves the database connection settings based on the Prisma schema file.
  */
-export const getDatabaseConfig = () => generateDatabaseConfig(dataSource, import.meta.url, schemaDir);
+export const getDatabaseConfig = () => generateDatabaseConfig(dataSource, import.meta.url, schemaDir, sourceFilePath);
 `;
 };
 

--- a/src/checkSchema.ts
+++ b/src/checkSchema.ts
@@ -1,0 +1,45 @@
+import assert from "assert";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+
+const migrate = async (schema: string, db: string) => {
+  process.env.DATABASE_URL = db;
+  execSync(`npx prisma migrate deploy --schema=${schema}`, {
+    stdio: "ignore",
+    env: process.env,
+  });
+  execSync(`npx prisma generate --schema=${schema}`, {
+    stdio: "ignore",
+    env: process.env,
+  });
+};
+
+(async () => {
+  {
+    await migrate("tests/check/schema1.prisma", "file:./test1.db");
+    // @ts-ignore
+    const { getDatabaseConfig } = await import("../tests/check/models1/index");
+    const config = getDatabaseConfig();
+    assert(config.datasourceUrl.endsWith("/tests/check/test1.db"));
+    assert(existsSync(config.datasourceUrl));
+  }
+
+  {
+    await migrate("tests/check/schema2.prisma", "file:./test2.db");
+    // @ts-ignore
+    const { getDatabaseConfig } = await import("../tests/check/models1/index");
+    const config = getDatabaseConfig();
+    assert(config.datasourceUrl.endsWith("/tests/check/test2.db"));
+    assert(existsSync(config.datasourceUrl));
+  }
+
+  {
+    await migrate("tests/check/schema3/main.prisma", "file:./test3.db");
+    // @ts-ignore
+    const { getDatabaseConfig } = await import("../tests/check/models3/index");
+    const config = getDatabaseConfig();
+    assert(config.datasourceUrl.endsWith("/tests/check/schema3/test3.db"));
+    assert(existsSync(config.datasourceUrl));
+  }
+  process.exit(0);
+})();

--- a/tests/check/schema1.prisma
+++ b/tests/check/schema1.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator custom_generator {
+  provider = "node node_modules/prisma-generator-accel-record"
+  output   = "./models1"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id Int @id @default(autoincrement()) @map("_id")
+}

--- a/tests/check/schema2.prisma
+++ b/tests/check/schema2.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+generator custom_generator {
+  provider = "node node_modules/prisma-generator-accel-record"
+  output   = "./models2"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id Int @id @default(autoincrement()) @map("_id")
+}

--- a/tests/check/schema3/main.prisma
+++ b/tests/check/schema3/main.prisma
@@ -1,0 +1,18 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder"]
+}
+
+generator custom_generator {
+  provider = "node node_modules/prisma-generator-accel-record"
+  output   = "../models3"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id Int @id @default(autoincrement()) @map("_id")
+}

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -771,6 +771,7 @@ registerModel(Book);
 
 
 export const schemaDir = "../prisma_mysql/";
+export const sourceFilePath = "../prisma_mysql/schema.prisma";
 export const dataSource = {
   "name": "db",
   "provider": "mysql",
@@ -785,4 +786,4 @@ export const dataSource = {
 /**
  * Retrieves the database connection settings based on the Prisma schema file.
  */
-export const getDatabaseConfig = () => generateDatabaseConfig(dataSource, import.meta.url, schemaDir);
+export const getDatabaseConfig = () => generateDatabaseConfig(dataSource, import.meta.url, schemaDir, sourceFilePath);

--- a/tests/models/dataSource.test.ts
+++ b/tests/models/dataSource.test.ts
@@ -1,5 +1,5 @@
-import { getDatabaseConfig, dataSource, schemaDir } from "./index";
 import { dbConfig } from "../vitest.setup";
+import { dataSource, getDatabaseConfig, schemaDir } from "./index";
 
 test("dataSource", () => {
   switch (dbConfig().type) {


### PR DESCRIPTION
- [accel-record] Changed to use `sourceFilePath` for calculating `datasourceUrl`. This fix resolves an issue where enabling `prismaSchemaFolder` and specifying a relative path for the SQLite datasource URL would cause a mismatch between the generated database file and the reference path.
- [prisma-generator-accel-record] The `sourceFilePath` is now output separately from `schemaDir` and is used in `generateDatabaseConfig()`.