### PR TITLE
[accella] load dotenv files

### DIFF
--- a/.changeset/nasty-students-appear.md
+++ b/.changeset/nasty-students-appear.md
@@ -1,0 +1,5 @@
+---
+"accella": minor
+---
+
+Implemented loadDotenvs() and called it at the beginning of runInitializers()

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+TEST_VALUE=myValue${VITEST_POOL_ID}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4149,9 +4149,23 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.1.tgz",
+      "integrity": "sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },
@@ -10793,7 +10807,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mojojs/path": "^1.7.0",
-        "accel-web": "^1.1.0"
+        "accel-web": "^1.1.0",
+        "dotenv": "^16.0.0",
+        "dotenv-expand": "^12.0.1"
       }
     },
     "packages/create-accella": {

--- a/packages/accella/package.json
+++ b/packages/accella/package.json
@@ -46,6 +46,8 @@
   "homepage": "https://github.com/koyopro/accella#readme",
   "dependencies": {
     "@mojojs/path": "^1.7.0",
-    "accel-web": "^1.1.0"
+    "accel-web": "^1.1.0",
+    "dotenv": "^16.0.0",
+    "dotenv-expand": "^12.0.0"
   }
 }

--- a/packages/accella/package.json
+++ b/packages/accella/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/middleware.d.ts",
       "default": "./dist/middleware.js"
     },
+    "./initialize": {
+      "types": "./dist/initialize.d.ts",
+      "default": "./dist/initialize.js"
+    },
     "./integration": {
       "types": "./dist/integration.d.ts",
       "default": "./dist/integration.js"

--- a/packages/accella/src/initialize.ts
+++ b/packages/accella/src/initialize.ts
@@ -1,4 +1,8 @@
+import * as dotenv from "dotenv";
+import * as dotenvExpand from "dotenv-expand";
+
 export const runInitializers = async () => {
+  loadDotenvs();
   const modules = import.meta.glob("/src/config/initializers/*");
   for (const path in modules) {
     try {
@@ -8,4 +12,9 @@ export const runInitializers = async () => {
       console.warn(`Error running initializer of ${path}`, error);
     }
   }
+};
+
+export const loadDotenvs = () => {
+  const path = [".env.local", `.env.${process.env.NODE_ENV}`, ".env"];
+  dotenvExpand.expand(dotenv.config({ path }));
 };

--- a/tests/models/initialize.test.ts
+++ b/tests/models/initialize.test.ts
@@ -1,0 +1,8 @@
+import { runInitializers } from "accella/initialize";
+
+test("runInitializers", async () => {
+  // TEST_VALUE is set in .env.test
+  expect(process.env.TEST_VALUE).toBeUndefined();
+  await runInitializers();
+  expect(process.env.TEST_VALUE).toBe(`myValue${process.env.VITEST_POOL_ID}`);
+});


### PR DESCRIPTION
Modified the runInitializers() function to load environment variables using dotenv and dotenv-expand during initialization.

`.env.local`, `.env.${process.env.NODE_ENV}`, `.env` are the files that will be loaded in the order of priority.