### PR TITLE
[accel-web] Added type restrictions to the arguments of each formFor component

### DIFF
--- a/.changeset/curly-mails-teach.md
+++ b/.changeset/curly-mails-teach.md
@@ -1,0 +1,5 @@
+---
+"accel-web": patch
+---
+
+Added type restrictions to the arguments of each formFor component

--- a/examples/web_astro/prisma/migrations/20250212171543_mod_todo/migration.sql
+++ b/examples/web_astro/prisma/migrations/20250212171543_mod_todo/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `Todo` ADD COLUMN `available` BOOLEAN NOT NULL DEFAULT true,
+    ADD COLUMN `label` VARCHAR(191) NULL;

--- a/examples/web_astro/prisma/schema.prisma
+++ b/examples/web_astro/prisma/schema.prisma
@@ -34,6 +34,8 @@ model Todo {
   estimate  Int?
   dueDate   DateTime?
   status    Status    @default(OPEN)
+  label     String?
+  available Boolean   @default(true)
   // account   Account   @relation(fields: [accountId], references: [id])
   // accountId Int
   createdAt DateTime  @default(now())

--- a/examples/web_astro/src/models/_types.ts
+++ b/examples/web_astro/src/models/_types.ts
@@ -103,6 +103,8 @@ declare module "./todo" {
     dueDate: Date | undefined;
     status: Status;
     statusText: string;
+    label: string | undefined;
+    available: boolean;
     createdAt: Date | undefined;
     updatedAt: Date | undefined;
   }
@@ -133,6 +135,8 @@ type TodoMeta = {
     estimate: number | undefined;
     dueDate: Date | undefined;
     status: Status;
+    label: string | undefined;
+    available: boolean;
     createdAt: Date;
     updatedAt: Date;
   };
@@ -143,6 +147,8 @@ type TodoMeta = {
     estimate?: number;
     dueDate?: Date;
     status?: Status;
+    label?: string;
+    available?: boolean;
     createdAt?: Date;
     updatedAt?: Date;
   };
@@ -153,6 +159,8 @@ type TodoMeta = {
     estimate?: number | number[] | Filter<number> | null;
     dueDate?: Date | Date[] | Filter<Date> | null;
     status?: Status | Status[] | undefined | null;
+    label?: string | string[] | StringFilter | null;
+    available?: boolean | boolean[] | undefined | null;
     createdAt?: Date | Date[] | Filter<Date> | null;
     updatedAt?: Date | Date[] | Filter<Date> | null;
   };

--- a/examples/web_astro/src/pages/todos/new.astro
+++ b/examples/web_astro/src/pages/todos/new.astro
@@ -28,14 +28,14 @@ const { Form, Label, TextField, Submit } = f;
           </div>
         )
       }
-      <f.HiddenField attr="secret" />
+      <f.HiddenField attr="id" />
       <div class="mb-3">
         <Label for="title" />
         <TextField attr="title" class="form-control" />
       </div>
       <div class="mb-3">
-        <Label for="description" />
-        <f.Textarea attr="description" class="form-control" />
+        <Label for="content" />
+        <f.Textarea attr="content" class="form-control" />
       </div>
       <div class="mb-3">
         <Label for="estimate" />

--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -50,32 +50,32 @@ export { CsrfMetaTags, CsrfTokenField };
  * - `Textarea`: A textarea input field component.
  * - `Submit`: A submit button component.
  */
-export const formFor = (resource: any, options?: FormForOptions) => {
+export const formFor = <T>(resource: T, options?: FormForOptions) => {
   const prefix = getPrefix(resource, options);
   return {
     Form: form as (props: astroHTML.JSX.FormHTMLAttributes) => any,
 
-    Label: makeLabel(prefix, resource),
+    Label: makeLabel<T>(prefix, resource),
 
-    TextField: makeTextField(prefix, resource),
+    TextField: makeTextField<T>(prefix, resource),
 
-    HiddenField: makeHiddenField(prefix, resource),
+    HiddenField: makeHiddenField<T>(prefix, resource),
 
-    PasswordField: makePasswordField(prefix),
+    PasswordField: makePasswordField<T>(prefix),
 
-    NumberField: makeNumberField(prefix, resource),
+    NumberField: makeNumberField<T>(prefix, resource),
 
-    DateField: makeDateField(prefix, resource),
+    DateField: makeDateField<T>(prefix, resource),
 
-    Checkbox: makeCheckbox(prefix, resource),
+    Checkbox: makeCheckbox<T>(prefix, resource),
 
-    RadioButton: makeRadioButton(prefix),
+    RadioButton: makeRadioButton<T>(prefix),
 
-    CollectionRadioButtons: makeCollectionRadioButtons(prefix, resource),
+    CollectionRadioButtons: makeCollectionRadioButtons<T>(prefix, resource),
 
-    Select: makeSelect(prefix, resource),
+    Select: makeSelect<T>(prefix, resource),
 
-    Textarea: makeTextarea(prefix, resource),
+    Textarea: makeTextarea<T>(prefix, resource),
 
     Submit: extendCommponent<"button", {}>(button, () => ({ type: "submit" })),
   };
@@ -101,11 +101,11 @@ export const extendCommponent = <L extends keyof astroHTML.JSX.DefinedIntrinsicE
   }) as any;
 };
 
-const makeSelect = (prefix: string, r: any) =>
+const makeSelect = <T>(prefix: string, r: any) =>
   extendCommponent<
     "select",
     {
-      attr: string;
+      attr: keyof T & string;
       collection: [string, string | undefined][];
       selected?: string;
       includeBlank?: string;
@@ -121,10 +121,10 @@ const makeSelect = (prefix: string, r: any) =>
     ["attr", "collection", "selected", "includeBlank"]
   );
 
-const makeCollectionRadioButtons = (
+const makeCollectionRadioButtons = <T>(
   prefix: string,
   r: any
-): ((props: { attr: string; collection: [string, string][] }) => any) => {
+): ((props: { attr: keyof T & string; collection: [string, string][] }) => any) => {
   return extendCommponent<"input", {}>(
     collectionRadioButtons,
     (p) => ({
@@ -136,8 +136,8 @@ const makeCollectionRadioButtons = (
   );
 };
 
-const makeLabel = (prefix: string, resource: any) => {
-  return extendCommponent<"label", { for: string }>(
+const makeLabel = <T>(prefix: string, resource: any) => {
+  return extendCommponent<"label", { for: keyof T & string }>(
     label,
     (p) => ({
       htmlFor: `${prefix}${p.for}`,
@@ -147,8 +147,8 @@ const makeLabel = (prefix: string, resource: any) => {
   );
 };
 
-const makeTextarea = (prefix: string, r: any) => {
-  return extendCommponent<"textarea", { attr: string }>(
+const makeTextarea = <T>(prefix: string, r: any) => {
+  return extendCommponent<"textarea", { attr: keyof T & string }>(
     textarea,
     (p) => ({ name: `${prefix}${p.attr}`, value: r[p.attr] }),
     ["attr"]

--- a/packages/accel-web/src/form/inputs.ts
+++ b/packages/accel-web/src/form/inputs.ts
@@ -1,31 +1,31 @@
 import { extendCommponent } from "./index.js";
 import input from "./input.astro";
 
-export const makeTextField = (prefix: string, r: any) => {
-  return extendCommponent<"input", { attr: string }>(
+export const makeTextField = <T>(prefix: string, r: any) => {
+  return extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({ name: `${prefix}${p.attr}`, value: r[p.attr], type: "text" }),
     ["attr"]
   );
 };
 
-export const makeHiddenField = (prefix: string, r: any) => {
-  return extendCommponent<"input", { attr: string }>(
+export const makeHiddenField = <T>(prefix: string, r: any) => {
+  return extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({ name: `${prefix}${p.attr}`, value: r[p.attr], type: "hidden" }),
     ["attr"]
   );
 };
 
-export const makePasswordField = (prefix: string) => {
-  return extendCommponent<"input", { attr: string }>(
+export const makePasswordField = <T>(prefix: string) => {
+  return extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({ name: `${prefix}${p.attr}`, type: "password" }),
     ["attr"]
   );
 };
-export const makeNumberField = (prefix: string, r: any) => {
-  return extendCommponent<"input", { attr: string }>(
+export const makeNumberField = <T>(prefix: string, r: any) => {
+  return extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({
       name: `+${prefix}${p.attr}`,
@@ -36,8 +36,8 @@ export const makeNumberField = (prefix: string, r: any) => {
   );
 };
 
-export const makeDateField = (prefix: string, r: any) =>
-  extendCommponent<"input", { attr: string }>(
+export const makeDateField = <T>(prefix: string, r: any) =>
+  extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({
       name: `${prefix}${p.attr}`,
@@ -47,8 +47,8 @@ export const makeDateField = (prefix: string, r: any) =>
     ["attr"]
   );
 
-export const makeCheckbox = (prefix: string, r: any) => {
-  return extendCommponent<"input", { attr: string }>(
+export const makeCheckbox = <T>(prefix: string, r: any) => {
+  return extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({
       name: `${prefix}${p.attr}`,
@@ -59,8 +59,8 @@ export const makeCheckbox = (prefix: string, r: any) => {
   );
 };
 
-export const makeRadioButton = (prefix: string) =>
-  extendCommponent<"input", { attr: string }>(
+export const makeRadioButton = <T>(prefix: string) =>
+  extendCommponent<"input", { attr: keyof T & string }>(
     input,
     (p) => ({
       name: `${prefix}${p.attr}`,

--- a/packages/accel-web/tests/formFor.test-d.ts
+++ b/packages/accel-web/tests/formFor.test-d.ts
@@ -1,0 +1,67 @@
+import { FormModel } from "accel-record";
+import { attributes } from "accel-record/attributes";
+import { formFor } from "src/index";
+
+test("formFor() with FormModel", async () => {
+  class SampleForm extends FormModel {
+    count = attributes.integer(0);
+  }
+  const form = SampleForm.build({});
+  const {
+    Label,
+    TextField,
+    HiddenField,
+    PasswordField,
+    NumberField,
+    DateField,
+    Checkbox,
+    RadioButton,
+    CollectionRadioButtons,
+    Select,
+    Textarea,
+  } = formFor(form);
+
+  Label({ for: "count" });
+  // @ts-expect-error
+  Label({ for: "invalidAttr" });
+
+  TextField({ attr: "count" });
+  // @ts-expect-error
+  TextField({ attr: "invalidAttr" });
+
+  HiddenField({ attr: "count" });
+  // @ts-expect-error
+  HiddenField({ attr: "invalidAttr" });
+
+  PasswordField({ attr: "count" });
+  // @ts-expect-error
+  PasswordField({ attr: "invalidAttr" });
+
+  NumberField({ attr: "count" });
+  // @ts-expect-error
+  NumberField({ attr: "invalidAttr" });
+
+  DateField({ attr: "count" });
+  // @ts-expect-error
+  DateField({ attr: "invalidAttr" });
+
+  Checkbox({ attr: "count" });
+  // @ts-expect-error
+  Checkbox({ attr: "invalidAttr" });
+
+  RadioButton({ attr: "count" });
+  // @ts-expect-error
+  RadioButton({ attr: "invalidAttr" });
+
+  CollectionRadioButtons({ attr: "count", collection: [["1", "one"]] });
+  // @ts-expect-error
+  CollectionRadioButtons({ attr: "invalidAttr", collection: [["1", "one"]] });
+
+  Select({ attr: "count", collection: [["1", "one"]] });
+  // @ts-expect-error
+  Select({ attr: "invalidAttr", collection: [["1", "one"]] });
+
+  Textarea({ attr: "count" });
+  // @ts-expect-error
+  Textarea({ attr: "invalidAttr" });
+});


### PR DESCRIPTION
```ts
import { FormModel } from "accel-record";
import { attributes } from "accel-record/attributes";
import { formFor } from "src/index";

test("formFor() with FormModel", async () => {
  class SampleForm extends FormModel {
    count = attributes.integer(0);
  }
  const form = SampleForm.build({});
  const { Label } = formFor(form);

  // ok
  Label({ for: "count" });
  // @ts-expect-error
  Label({ for: "invalidAttr" });
});
```