### PR TITLE
[examples/basics] Added sessionOptions to src/config/session.ts

### DIFF
--- a/examples/basics/src/config/session.ts
+++ b/examples/basics/src/config/session.ts
@@ -1,4 +1,4 @@
-import { type Session as BaseSession } from "accella/session";
+import { type Session as BaseSession, type Options } from "accella/session";
 
 // You can define the type of the session object here
 export type SessionData = {
@@ -6,3 +6,14 @@ export type SessionData = {
 };
 
 export type Session = BaseSession & Partial<SessionData>;
+
+export const sessionOptions: Options = {
+  // cookieName: "astro.session",
+  // cookieSetOptions: {
+  //   httpOnly: true,
+  //   secure: import.meta.env.PROD,
+  //   path: undefined,
+  //   expires: undefined,
+  //   maxAge: undefined,
+  // },
+};


### PR DESCRIPTION
current `examples/basics/src/config/session.ts`:
```ts
import { type Session as BaseSession, type Options } from "accella/session";

// You can define the type of the session object here
export type SessionData = {
  [key: string]: any;
};

export type Session = BaseSession & Partial<SessionData>;

export const sessionOptions: Options = {
  // cookieName: "astro.session",
  // cookieSetOptions: {
  //   httpOnly: true,
  //   secure: import.meta.env.PROD,
  //   path: undefined,
  //   expires: undefined,
  //   maxAge: undefined,
  // },
};
```