### PR TITLE
[accel-record] Restricted the argument type of Model.humanAttributeName()

### DIFF
--- a/.changeset/nasty-peas-march.md
+++ b/.changeset/nasty-peas-march.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": patch
+"accel-record": patch
+---
+
+Restricted the argument type of Model.humanAttributeName()

--- a/.changeset/smooth-rules-beam.md
+++ b/.changeset/smooth-rules-beam.md
@@ -1,0 +1,5 @@
+---
+"accel-web": patch
+---
+
+Adapting to the change in the argument type of Accel Record's Model.humanAttributeName()

--- a/examples/basics/src/config/initializers/i18n.ts
+++ b/examples/basics/src/config/initializers/i18n.ts
@@ -1,0 +1,13 @@
+import i18next from "i18next";
+
+export default async () => {
+  await i18next.init({ lng: "en", resources: { en } });
+};
+
+const en = {
+  translation: {
+    // "accelrecord.models.User": "User",
+    // "accelrecord.attributes.User.firstName": "First Name",
+    // "accelrecord.attributes.User.lastName": "Last Name",
+  },
+};

--- a/packages/accel-record-core/src/model/naming.ts
+++ b/packages/accel-record-core/src/model/naming.ts
@@ -31,7 +31,10 @@ export class Naming {
    * @param attribute - The attribute name.
    * @returns The human-readable attribute name.
    */
-  static humanAttributeName(attribute: string) {
+  static humanAttributeName<T extends { new (): any }>(
+    this: T,
+    attribute: keyof InstanceType<T> & string
+  ) {
     const key = `accelrecord.attributes.${this.name}.${attribute}`;
     return i18n?.t(key, "") || toPascalCase(attribute);
   }

--- a/packages/accel-record-core/src/model/securePassword.ts
+++ b/packages/accel-record-core/src/model/securePassword.ts
@@ -75,7 +75,7 @@ export function hasSecurePassword<T extends string = "password">(
         length: { maximum: MAX_PASSWORD_LENGTH_ALLOWED },
       });
       if (confirm != undefined && password !== confirm) {
-        const humanAttributeName = this.record.class().humanAttributeName(attribute);
+        const humanAttributeName = this.record.class().humanAttributeName(attribute as keyof Model);
         this.record.errors.add(confirmAttribute, "confirmation", {
           attribute: humanAttributeName,
         });

--- a/packages/accel-record-core/src/validation/errors.ts
+++ b/packages/accel-record-core/src/validation/errors.ts
@@ -47,7 +47,7 @@ export class Error {
    * @returns The full error message.
    */
   get fullMessage() {
-    const attrName = this.base.class().humanAttributeName(this.attribute);
+    const attrName = this.base.class().humanAttributeName(this.attribute as keyof Model);
     return `${attrName} ${this.message}`;
   }
 

--- a/packages/accel-web/src/form/index.ts
+++ b/packages/accel-web/src/form/index.ts
@@ -161,10 +161,10 @@ function toCamelCase(str: string): string {
 
 const humanAttributeName = (resource: any, name: string) => {
   if (resource instanceof Model) {
-    return resource.class().humanAttributeName(name);
+    return resource.class().humanAttributeName(name as keyof Model);
   }
   if (resource instanceof FormModel) {
-    return resource.class().humanAttributeName(name);
+    return resource.class().humanAttributeName(name as keyof FormModel);
   }
   return undefined;
 };

--- a/tests/models/model/naming.test-d.ts
+++ b/tests/models/model/naming.test-d.ts
@@ -1,0 +1,10 @@
+import { Setting, User } from "..";
+
+test("humanAttributeName", () => {
+  User.humanAttributeName("name");
+  Setting.humanAttributeName("counter");
+  // @ts-expect-error
+  User.humanAttributeName("invalid");
+  // @ts-expect-error
+  Setting.humanAttributeName("foo");
+});


### PR DESCRIPTION
- [accel-record] Restricted the argument type of Model.humanAttributeName()
- [accel-web] Adapting to the change in the argument type of Accel Record's Model.humanAttributeName()
- [examples/basics] Add I18n initializer

```ts
test("humanAttributeName", () => {
  User.humanAttributeName("name");
  Setting.humanAttributeName("counter");
  // @ts-expect-error
  User.humanAttributeName("invalid");
  // @ts-expect-error
  Setting.humanAttributeName("foo");
});
```