### PR TITLE
[prisma-generator-accel-record] Fix: Include json type columns in the Column

### DIFF
--- a/.changeset/thirty-dolls-report.md
+++ b/.changeset/thirty-dolls-report.md
@@ -1,0 +1,5 @@
+---
+"prisma-generator-accel-record": patch
+---
+
+Fix: Include json type columns in the Column

--- a/packages/prisma-generator-accel-record/src/generators/model/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/model/type.ts
@@ -121,11 +121,12 @@ const associationKey = (model: ModelWrapper) => {
 
 const columnMeta = (model: ModelWrapper) =>
   model.fields
-    .filter((f) => !f.relationName && f.type != "Json")
-    .map(
-      (field) =>
-        `\n    ${field.name}: ${field.typeName}${field.isList ? "[]" : ""}${
-          field.isRequired ? "" : " | undefined"
-        };`
-    )
+    .filter((f) => !f.relationName)
+    .map((field) => {
+      const type =
+        field.type == "Json"
+          ? `${model.baseModel}['${field.name}']`
+          : `${field.typeName}${field.isList ? "[]" : ""}`;
+      return `\n    ${field.name}: ${type}${field.isRequired ? "" : " | undefined"};`;
+    })
     .join("") + "\n  ";

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -393,6 +393,7 @@ type SettingMeta = {
     userId: number;
     threshold: number | undefined;
     createdAt: Date;
+    data: SettingModel['data'];
   };
   CreateInput: {
     settingId?: number;

--- a/tests/models/serialization.test-d.ts
+++ b/tests/models/serialization.test-d.ts
@@ -1,3 +1,4 @@
+import { $setting } from "tests/factories/setting";
 import { $user } from "../factories/user";
 
 test("toHash", () => {
@@ -84,4 +85,10 @@ test("toHash with include belongsTo", () => {
     // @ts-expect-error
     user.id;
   }
+});
+
+test("toHash with only Json column", () => {
+  const setting = $setting.create();
+
+  setting.toHash({ only: ["data"] });
 });


### PR DESCRIPTION
Fixed the issue where the JSON column was not reflected in the Column of Meta type.