### PR TITLE
[accella] Exclude CSRF token validation for Astro Actions endpoints

### DIFF
--- a/.changeset/purple-wombats-hug.md
+++ b/.changeset/purple-wombats-hug.md
@@ -1,0 +1,6 @@
+---
+"accel-web": patch
+"accella": patch
+---
+
+Exclude CSRF token validation for Astro Actions endpoints

--- a/packages/accel-web/src/csrf.ts
+++ b/packages/accel-web/src/csrf.ts
@@ -72,6 +72,8 @@ export const validateAuthenticityToken = (
   request: Request
 ) => {
   if (!["POST", "PATCH", "DELETE", "PUT"].includes(request.method)) return;
+  const path = new URL(request.url).pathname;
+  if (path.startsWith("/_actions/")) return; // Astro Actions
 
   const authenticityToken: string =
     params["authenticity_token"] ?? request.headers.get("X-CSRF-Token") ?? "";

--- a/packages/accel-web/tests/csrf.test.ts
+++ b/packages/accel-web/tests/csrf.test.ts
@@ -97,6 +97,13 @@ test("validateAuthenticityToken()", async () => {
     });
     await expect(result(request)).resolves.not.toThrow();
   }
+  {
+    // Invalid but Astro Actions
+    const request = new Request(`http://localhost/_actions/hello`, {
+      method: "POST",
+    });
+    await expect(result(request)).resolves.not.toThrow();
+  }
 });
 
 test("defineAuthenticityToken()", async () => {


### PR DESCRIPTION
Fixed an issue where CSRF token validation was causing Astro Actions requests to result in a 500 error.