### PR TITLE
[accel-record] attribute decorator

### DIFF
--- a/.changeset/cute-monkeys-arrive.md
+++ b/.changeset/cute-monkeys-arrive.md
@@ -1,0 +1,7 @@
+---
+"prisma-generator-accel-record": minor
+"accel-record-core": minor
+"accel-record": minor
+---
+
+Setter methods marked with `attribute` decorator will be included in the type definition and can be used as arguments for methods like create or update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7560,6 +7560,11 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -9925,6 +9930,7 @@
         "get-port": "^7.0.0",
         "knex": "^3.0.0",
         "prisma": ">=6.5.0",
+        "reflect-metadata": "^0.2.2",
         "sync-actions": "^1.0.0",
         "uuid": "^11.0.0"
       },
@@ -9989,7 +9995,8 @@
         "@prisma/client": ">=5.0.0",
         "@prisma/generator-helper": ">=5.0.0",
         "esbuild": ">=0.25.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "reflect-metadata": "^0.2.2"
       },
       "bin": {
         "prisma-generator-accel-record": "dist/bin.js"

--- a/packages/accel-record-core/package.json
+++ b/packages/accel-record-core/package.json
@@ -32,6 +32,7 @@
     "get-port": "^7.0.0",
     "knex": "^3.0.0",
     "prisma": ">=6.5.0",
+    "reflect-metadata": "^0.2.0",
     "sync-actions": "^1.0.0",
     "uuid": "^11.0.0"
   },

--- a/packages/accel-record-core/src/index.ts
+++ b/packages/accel-record-core/src/index.ts
@@ -26,6 +26,7 @@ export { ModelBase } from "./model/base.js";
 export { hasSecurePassword } from "./model/securePassword.js";
 export { Relation } from "./relation/index.js";
 export { scope } from "./scope.js";
+export { attribute } from "./model/attribute.js";
 export { DatabaseCleaner } from "./testUtils.js";
 export { Rollback } from "./transaction.js";
 export { Errors } from "./validation/errors.js";

--- a/packages/accel-record-core/src/model/attribute.ts
+++ b/packages/accel-record-core/src/model/attribute.ts
@@ -1,0 +1,16 @@
+import "reflect-metadata/lite";
+/**
+ * Setter methods marked with \@attribute will be included in the type definition and can be used as arguments for methods like create or update.
+ *
+ * @example
+ * export class ArticleModel extends ApplicationRecord {
+ *  \@attribute
+ *  set published(value: boolean) {
+ *    this.status = value ? "published" : "draft";
+ *  }
+ * }
+ */
+export function attribute(method: any, _context: any) {
+  Reflect.defineMetadata("accelRecord:attribute", true, method);
+  return method;
+}

--- a/packages/prisma-generator-accel-record/package.json
+++ b/packages/prisma-generator-accel-record/package.json
@@ -32,7 +32,8 @@
     "@prisma/client": ">=5.0.0",
     "@prisma/generator-helper": ">=5.0.0",
     "esbuild": ">=0.25.0",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "reflect-metadata": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.0",

--- a/packages/prisma-generator-accel-record/src/generators/relation.ts
+++ b/packages/prisma-generator-accel-record/src/generators/relation.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import { ModelWrapper } from "./wrapper";
 
-const loadModels = async (options: GeneratorOptions) => {
+export const loadModels = async (options: GeneratorOptions) => {
   const outputDir = options.generator.output!.value!;
   const filePath = path.join(outputDir, "index.ts");
   const outfile = path.join(__dirname, "../.models.mjs");

--- a/packages/prisma-generator-accel-record/src/generators/type.ts
+++ b/packages/prisma-generator-accel-record/src/generators/type.ts
@@ -1,9 +1,10 @@
 import { GeneratorOptions } from "@prisma/generator-helper";
 import { generateModelTypes } from "./model/type.js";
-import { relationMethods } from "./relation.js";
+import { loadModels, relationMethods } from "./relation.js";
 import { ModelWrapper } from "./wrapper.js";
 
 export const generateTypes = async (options: GeneratorOptions) => {
+  const modelImpls = await loadModels(options);
   return `import {
   generateDatabaseConfig,
   registerModel,
@@ -24,13 +25,13 @@ declare module "accel-record" {
 
 type Meta<T> = ${meta(options)}
                any;
-${enumData(options)}${models(options)}`;
+${enumData(options)}${models(options, modelImpls)}`;
 };
 
-const models = (options: GeneratorOptions) => {
+const models = (options: GeneratorOptions, modelImpls: any) => {
   let data = "";
   for (const model of options.dmmf.datamodel.models)
-    data += generateModelTypes(new ModelWrapper(model, options.dmmf.datamodel));
+    data += generateModelTypes(new ModelWrapper(model, options.dmmf.datamodel, modelImpls));
   return data;
 };
 

--- a/packages/prisma-generator-accel-record/src/generators/wrapper.ts
+++ b/packages/prisma-generator-accel-record/src/generators/wrapper.ts
@@ -67,7 +67,8 @@ export class FieldWrapper {
 export class ModelWrapper {
   constructor(
     private model: DMMF.Model,
-    private datamodel: DMMF.Datamodel
+    private datamodel: DMMF.Datamodel,
+    private modelImpls: Record<string, { new (): any } | undefined> = {}
   ) {}
 
   get baseModel() {
@@ -78,6 +79,9 @@ export class ModelWrapper {
   }
   get persistedModel() {
     return `${this.model.name}`;
+  }
+  get class(): { new (): any } | undefined {
+    return this.modelImpls[this.persistedModel];
   }
   get collection() {
     return `${this.model.name}Collection`;

--- a/packages/prisma-generator-accel-record/src/utils/method.ts
+++ b/packages/prisma-generator-accel-record/src/utils/method.ts
@@ -1,0 +1,16 @@
+export const getInstanceMethods = <T>(arg: new (...args: any[]) => T) => {
+  const properties = new Map<string, any>();
+  let currentProto = arg.prototype;
+
+  while (currentProto && currentProto !== Object.prototype) {
+    Object.getOwnPropertyNames(currentProto).forEach((prop) => {
+      const descriptor = Object.getOwnPropertyDescriptor(currentProto, prop);
+      if (prop != "constructor" && descriptor) {
+        properties.set(prop, descriptor);
+      }
+    });
+    currentProto = Object.getPrototypeOf(currentProto);
+  }
+
+  return properties;
+};

--- a/tests/models/_types.ts
+++ b/tests/models/_types.ts
@@ -301,6 +301,7 @@ type PostMeta = {
     content?: string;
     published?: boolean;
     tags?: PostTagModel[];
+    hidden?: PostModel['hidden'];
   } & ({ author: User } | { authorId: number });
   WhereInput: {
     id?: number | number[] | Filter<number> | null;

--- a/tests/models/model/attribute.test.ts
+++ b/tests/models/model/attribute.test.ts
@@ -1,0 +1,7 @@
+import { UserFactory as $user } from "tests/factories/user";
+import { Post } from "..";
+
+test("@attribute decorator", () => {
+  const p = Post.create({ title: "foo", author: $user.create(), hidden: true });
+  expect(p.published).toBe(false);
+});

--- a/tests/models/post.ts
+++ b/tests/models/post.ts
@@ -1,4 +1,4 @@
-import { scope } from "accel-record";
+import { attribute, scope } from "accel-record";
 import { ApplicationRecord } from "./applicationRecord.js";
 
 export class PostModel extends ApplicationRecord {
@@ -8,5 +8,9 @@ export class PostModel extends ApplicationRecord {
   }
   override validateAttributes() {
     this.validates("title", { presence: true });
+  }
+  @attribute
+  set hidden(value: boolean) {
+    this.published = !value;
   }
 }


### PR DESCRIPTION
Setter methods marked with attribute decorator will be included in the type definition and can be used as arguments for methods like create or update.

```ts
import { attribute } from "accel-record";

export class ArticleModel extends ApplicationRecord {
  @attribute
  set published(value: boolean) {
     this.status = value ? "published" : "draft";
  }
}
```

```ts
// Allowed without type error
Article.create({ published: true })