### PR TITLE
[accella] Throw PendingMigrationsError when there are pending migrations

### DIFF
--- a/.changeset/curvy-apes-sing.md
+++ b/.changeset/curvy-apes-sing.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": minor
+"accel-record": minor
+---
+
+add Migration.hasPendingMigrations() method

--- a/.changeset/rare-nails-run.md
+++ b/.changeset/rare-nails-run.md
@@ -1,0 +1,6 @@
+---
+"accel-record-core": minor
+"accel-record": minor
+---
+
+Add step option to Migrate.migrate()

--- a/.changeset/wicked-berries-cheer.md
+++ b/.changeset/wicked-berries-cheer.md
@@ -1,0 +1,5 @@
+---
+"accella": minor
+---
+
+Throw a PendingMigrationsError if there are pending migrations in the development environment.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
       - run: npm run test -w accel-web
       - run: npm run test -w accel-wave
       - run: npm run generate:mysql
+      - run: npx accel run src/checkMigration.ts
       - run: npm run test:mysql
       - run: npm run sample
       - run: npm run generate:sqlite

--- a/packages/accel-record-core/src/errors.ts
+++ b/packages/accel-record-core/src/errors.ts
@@ -1,2 +1,10 @@
 export class RecordNotFound extends Error {}
 export class AttributeNotFound extends Error {}
+export class PendingMigrationError extends Error {
+  constructor(message?: string) {
+    super(
+      message || "Migrations are pending. Please run `npx prisma migrate deploy` to apply them."
+    );
+    this.name = "PendingMigrationError";
+  }
+}

--- a/packages/accel-record-core/src/migration.ts
+++ b/packages/accel-record-core/src/migration.ts
@@ -141,5 +141,8 @@ export class Migration {
 }
 
 const sha256hash = (buffer: Buffer) => {
-  return crypto.createHash("sha256").update(buffer).digest("hex");
+  return crypto
+    .createHash("sha256")
+    .update(buffer as any)
+    .digest("hex");
 };

--- a/packages/accel-record-core/src/migration/mysqlMigrator.ts
+++ b/packages/accel-record-core/src/migration/mysqlMigrator.ts
@@ -14,6 +14,15 @@ export class MySQLMigrator extends Migrator {
     knex.destroy();
   }
 
+  async isDatabaseExists(): Promise<boolean> {
+    const [database, newConfig] = parseConfig();
+    const knex = Knex(newConfig);
+    const exists = await knex.raw(`SHOW DATABASES LIKE "${database}";`);
+    const result = exists[0].length > 0;
+    knex.destroy();
+    return result;
+  }
+
   async createLogsTableIfNotExists() {
     return this.knex.raw(CREATE_LOGS_TABLE_DDL);
   }

--- a/packages/accel-record-core/src/migration/postgresqlMigrator.ts
+++ b/packages/accel-record-core/src/migration/postgresqlMigrator.ts
@@ -14,6 +14,15 @@ export class PostgresqlMigrator extends Migrator {
     knex.destroy();
   }
 
+  async isDatabaseExists(): Promise<boolean> {
+    const [database, newConfig] = parseConfig();
+    const knex = Knex(newConfig);
+    const exists = await knex.raw(`SELECT 1 FROM pg_database WHERE datname='${database}'`);
+    const result = exists.rows.length > 0;
+    knex.destroy();
+    return result;
+  }
+
   async createLogsTableIfNotExists() {
     return this.knex.raw(CREATE_LOGS_TABLE_DDL);
   }

--- a/packages/accel-record-core/src/migration/sqliteMigrator.ts
+++ b/packages/accel-record-core/src/migration/sqliteMigrator.ts
@@ -8,6 +8,10 @@ export class SqliteMigrator extends Migrator {
   async createLogsTableIfNotExists() {
     return this.knex.raw(CREATE_LOGS_TABLE_DDL);
   }
+
+  async isDatabaseExists(): Promise<boolean> {
+    return true;
+  }
 }
 
 const CREATE_LOGS_TABLE_DDL = `CREATE TABLE IF NOT EXISTS "_prisma_migrations" (

--- a/packages/accella/src/middleware.ts
+++ b/packages/accella/src/middleware.ts
@@ -1,4 +1,5 @@
-import { RecordNotFound } from "accel-record/errors";
+import { Migration } from "accel-record";
+import { PendingMigrationError, RecordNotFound } from "accel-record/errors";
 import { RequestParameters } from "accel-web";
 import { defineAuthenticityToken, validateAuthenticityToken } from "accel-web/csrf";
 import { APIContext } from "astro";
@@ -9,6 +10,9 @@ import { getSession } from "./session";
 await runInitializers();
 
 export const onRequest = async (context: APIContext, next: any) => {
+  if (process.env.NODE_ENV == "development" && (await Migration.hasPendingMigrations()))
+    throw new PendingMigrationError();
+
   const { cookies, request, params, locals } = context;
   locals.session = getSession(cookies);
   locals.params = await RequestParameters.from(request, params);

--- a/src/checkMigration.ts
+++ b/src/checkMigration.ts
@@ -1,0 +1,32 @@
+import { initAccelRecord, Migration, Model } from "accel-record";
+import assert from "assert";
+import { getDatabaseConfig } from "../tests/models/index.js";
+
+const subject = async () => Migration.hasPendingMigrations();
+
+const setup = async () => {
+  await initAccelRecord({
+    ...getDatabaseConfig(),
+    datasourceUrl: `mysql://root:@localhost:3306/test_migrations`,
+  });
+};
+
+export default async () => {
+  await setup();
+
+  // Scenario 1: The database does not exist
+  Model.connection.execute("drop database if exists test_migrations", []);
+  assert.equal(await subject(), true);
+
+  // Scenario 2: The database exists but the log table does not
+  await Migration.ensureDatabaseExists();
+  assert.equal(await subject(), true);
+
+  // Scenario 3: There are pending migrations
+  await Migration.migrate({ step: 3 });
+  assert.equal(await subject(), true);
+
+  // Scenario 4: All migrations have been applied
+  await Migration.migrate();
+  assert.equal(await subject(), false);
+};

--- a/src/checkMigration.ts
+++ b/src/checkMigration.ts
@@ -11,11 +11,14 @@ const setup = async () => {
   });
 };
 
+const teardown = async () => {
+  await Model.connection.execute("drop database if exists test_migrations", []);
+};
+
 export default async () => {
   await setup();
 
   // Scenario 1: The database does not exist
-  Model.connection.execute("drop database if exists test_migrations", []);
   assert.equal(await subject(), true);
 
   // Scenario 2: The database exists but the log table does not
@@ -29,4 +32,7 @@ export default async () => {
   // Scenario 4: All migrations have been applied
   await Migration.migrate();
   assert.equal(await subject(), false);
+
+  // cleanup
+  await teardown();
 };


### PR DESCRIPTION
- [accel-record] Add Migration.hasPendingMigrations() method
- [accel-record] Add step option to Migrate.migrate()
  - `await Migration.migrate({ step: 3 });`
- [accella] Throw a PendingMigrationsError if there are pending migrations in the development environment.
  - <img width="941" alt="image" src="https://github.com/user-attachments/assets/df900cdf-48d1-4e07-a088-61233b622532" />
