### PR TITLE
[accel-web] Update the version of astro-cookie-session dependency

### DIFF
--- a/.changeset/curly-masks-talk.md
+++ b/.changeset/curly-masks-talk.md
@@ -1,0 +1,5 @@
+---
+"accel-web": patch
+---
+
+Update the version of astro-cookie-session dependency to 1.2.0 or higher

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/node": "^9.0.1",
-        "accella": "^1.0.1",
+        "accella": "^1.1.0",
         "astro": "^5.1.7",
         "dotenv": "^16.4.5",
         "mysql2": "^3.9.8",
@@ -4485,9 +4485,9 @@
       }
     },
     "node_modules/astro-cookie-session": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/astro-cookie-session/-/astro-cookie-session-1.1.0.tgz",
-      "integrity": "sha512-EYd6m17M5KucS8xXDd0W8ITDLy4OGSZzwrVtGbqhxpsIYUuhamMpNy+L/uTc2+zD5eFyeyZxAqhPY2mJ3YjueA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/astro-cookie-session/-/astro-cookie-session-1.2.0.tgz",
+      "integrity": "sha512-u0YQnAwd2lLKdtuhPoOh4pZGbUoJrX0K8xkGreIVdri4UM7ik37WzZt9luIMuYejLkxH6VTH4yw++wLbu5foGA==",
       "dependencies": {
         "astro": ">=4.0.0",
         "jsonwebtoken": "^9.0.0"
@@ -12369,14 +12369,14 @@
       "dependencies": {
         "accel-record": ">=2.1.1",
         "astro": ">=4.16.18",
-        "astro-cookie-session": "^1.1.0",
+        "astro-cookie-session": "^1.2.0",
         "csrf": "^3.1.0",
         "i18next": ">=23.0.0",
         "parse-nested-form-data": "^1.0.0"
       }
     },
     "packages/accella": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mojojs/path": "^1.7.0",

--- a/packages/accel-web/package.json
+++ b/packages/accel-web/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "accel-record": ">=2.1.1",
     "astro": ">=4.16.18",
-    "astro-cookie-session": "^1.1.0",
+    "astro-cookie-session": "^1.2.0",
     "csrf": "^3.1.0",
     "i18next": ">=23.0.0",
     "parse-nested-form-data": "^1.0.0"


### PR DESCRIPTION
- Update the version of astro-cookie-session dependency to 1.2.0 or higher