### PR TITLE
[accella] Added support for custom commands

### DIFF
--- a/.changeset/unlucky-knives-move.md
+++ b/.changeset/unlucky-knives-move.md
@@ -1,0 +1,5 @@
+---
+"accella": minor
+---
+
+Added support for custom commands

--- a/examples/web_astro/src/commands/index.ts
+++ b/examples/web_astro/src/commands/index.ts
@@ -1,0 +1,11 @@
+import { program } from "accella";
+import { Account } from "../models";
+
+program
+  .command("hello")
+  .description("Hello command")
+  .action(() => {
+    console.log("Hello from Accella!");
+    const count = Account.count();
+    console.log(`Total accounts: ${count}`);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11615,6 +11615,7 @@
       "dependencies": {
         "@mojojs/path": "^1.7.0",
         "accel-web": "^1.1.4",
+        "commander": ">=10.0.0",
         "dotenv": "^16.0.0",
         "dotenv-expand": "^12.0.0"
       },

--- a/packages/accella/package.json
+++ b/packages/accella/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@mojojs/path": "^1.7.0",
     "accel-web": "^1.1.4",
+    "commander": ">=10.0.0",
     "dotenv": "^16.0.0",
     "dotenv-expand": "^12.0.0"
   }

--- a/packages/accella/src/bin.ts
+++ b/packages/accella/src/bin.ts
@@ -1,8 +1,45 @@
 #!/usr/bin/env node
 
-import { cli } from "./cli.js";
+import { Command } from "commander";
+import fs from "fs";
+import path from "path";
+import { runScript } from "./vite.js";
 
-cli().catch((err) => {
-  console.error("Execution error:", err);
-  process.exit(1);
-});
+async function command() {
+  const program = await getProgram();
+  registerRunCommand(program);
+  await importTasks();
+  await program.parseAsync();
+  process.exit(0);
+}
+
+async function getProgram(): Promise<Command> {
+  const cli = await runScript(
+    path.resolve(path.dirname(import.meta.url.replace("file:", "")), "cli.js")
+  );
+  return cli.program;
+}
+
+function registerRunCommand(program: any) {
+  program
+    .command("run")
+    .description("Run a TypeScript file")
+    .argument("<file>", "Path to the TypeScript file")
+    .action(async (file: any) => {
+      await runScript(path.resolve(process.cwd(), file));
+    });
+}
+
+async function importTasks() {
+  const tasksDir = path.join(process.cwd(), "src/commands");
+  if (fs.existsSync(tasksDir)) {
+    const files = fs.readdirSync(tasksDir);
+    const tsFiles = files.filter((file) => /(ts|js)$/.test(file));
+    for (const file of tsFiles) {
+      const filepath = path.resolve(tasksDir, file);
+      await runScript(filepath);
+    }
+  }
+}
+
+await command();

--- a/packages/accella/src/cli.ts
+++ b/packages/accella/src/cli.ts
@@ -1,59 +1,6 @@
-import { ViteUserConfig } from "astro";
-import { getViteConfig } from "astro/config";
-import fs from "fs/promises";
-import path from "path";
-import { createServer } from "vite";
+import { Command } from "commander";
 
-const createViteServer = async (config: ViteUserConfig) => {
-  const viteConfig = await getViteConfig(config)({ command: "serve", mode: "development" });
-  const vite = await createServer(viteConfig as any);
-  return vite;
-};
+const program = new Command();
+program.name("accel").description("Accella CLI tools").version("1.0.0");
 
-async function runScript(filepath: string): Promise<void> {
-  try {
-    await fs.access(filepath);
-
-    const vite = await createViteServer({});
-
-    try {
-      const initializeModule = await vite.ssrLoadModule(
-        path.resolve(path.dirname(import.meta.url.replace("file:", "")), "initialize.js")
-      );
-      await initializeModule.runInitializers();
-
-      const module = await vite.ssrLoadModule(filepath);
-
-      if (typeof module.default === "function") {
-        await module.default();
-      } else if (typeof module.main === "function") {
-        await module.main();
-      }
-    } finally {
-      await vite.close();
-    }
-  } catch (error) {
-    console.error(`File execution error: ${filepath}`);
-    console.error(error);
-    process.exit(1);
-  }
-}
-
-export async function cli() {
-  const args = process.argv.slice(2);
-
-  if (args.length < 1) {
-    console.error("Usage: accel run <path to ts file>");
-    process.exit(1);
-  }
-
-  const command = args[0];
-
-  if (command === "run" && args[1]) {
-    await runScript(path.resolve(process.cwd(), args[1]));
-    process.exit(0);
-  } else {
-    console.error("Usage: accel run <path to ts file>");
-    process.exit(1);
-  }
-}
+export { program };

--- a/packages/accella/src/index.ts
+++ b/packages/accella/src/index.ts
@@ -1,4 +1,5 @@
 import Path from "@mojojs/path";
+export { program } from "./cli.js";
 
 export const Accel = {
   get root(): Path {

--- a/packages/accella/src/vite.ts
+++ b/packages/accella/src/vite.ts
@@ -1,0 +1,63 @@
+import { ViteUserConfig } from "astro";
+import { getViteConfig } from "astro/config";
+import fs from "fs/promises";
+import path from "path";
+import { createServer } from "vite";
+
+let viteServer: Awaited<ReturnType<typeof createServer>> | null = null;
+
+const createViteServer = async (config: ViteUserConfig) => {
+  if (viteServer) {
+    return viteServer;
+  }
+
+  const viteConfig = await getViteConfig(config)({ command: "serve", mode: "development" });
+  viteServer = await createServer(viteConfig as any);
+
+  const initializeModule = await viteServer.ssrLoadModule(
+    path.resolve(path.dirname(import.meta.url.replace("file:", "")), "initialize.js")
+  );
+  await initializeModule.runInitializers();
+
+  return viteServer;
+};
+
+const closeViteServer = async () => {
+  if (viteServer) {
+    await viteServer.close();
+    viteServer = null;
+  }
+};
+
+process.on("SIGINT", async () => {
+  await closeViteServer();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await closeViteServer();
+  process.exit(0);
+});
+
+async function runScript(filepath: string): Promise<any> {
+  try {
+    await fs.access(filepath);
+
+    const vite = await createViteServer({});
+
+    const module = await vite.ssrLoadModule(filepath);
+
+    if (typeof module.default === "function") {
+      await module.default();
+    } else if (typeof module.main === "function") {
+      await module.main();
+    }
+    return module;
+  } catch (error) {
+    console.error(`File execution error: ${filepath}`);
+    console.error(error);
+    throw error;
+  }
+}
+
+export { closeViteServer, runScript };


### PR DESCRIPTION
Added functionality to register CLI commands in the files under `src/commands/`.
You can execute custom processes with the database connection fully initialized.

```ts
// examples/web_astro/src/commands/index.ts
import { program } from "accella";
import { Account } from "../models";

program
  .command("hello")
  .description("Hello command")
  .action(() => {
    console.log("Hello from Accella!");
    const count = Account.count();
    console.log(`Total accounts: ${count}`);
  });
```

```sh
# Run the command
$ npx accel hello
Hello from Accella!
Total accounts: 5
```